### PR TITLE
Use Format name in template generation script

### DIFF
--- a/generate-format.sh
+++ b/generate-format.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 export LOWER_CASE_FORMAT=`echo $FORMAT | tr '[:upper:]' '[:lower:]'`
 mkdir ext-src/packages/$LOWER_CASE_FORMAT
 
@@ -6,6 +7,11 @@ export COORDINATE_FILENAME="${FORMAT}Coordinate.ts"
 export DEPENDENCIES_FILENAME="${FORMAT}Dependencies.ts"
 export PACKAGE_FILENAME="${FORMAT}Package.ts"
 
-mustache ext-src/packages/templates/variables.json ext-src/packages/templates/Coordinate.mustache > ext-src/packages/$LOWER_CASE_FORMAT/$COORDINATE_FILENAME
-mustache ext-src/packages/templates/variables.json ext-src/packages/templates/Dependencies.mustache > ext-src/packages/$LOWER_CASE_FORMAT/$DEPENDENCIES_FILENAME
-mustache ext-src/packages/templates/variables.json ext-src/packages/templates/Package.mustache > ext-src/packages/$LOWER_CASE_FORMAT/$PACKAGE_FILENAME
+tmpviewfile=$(mktemp /tmp/viewfile.json)
+sed 's/Example/'"$FORMAT"'/g' ext-src/packages/templates/variables.json > $tmpviewfile
+
+mustache $tmpviewfile ext-src/packages/templates/Coordinate.mustache > ext-src/packages/$LOWER_CASE_FORMAT/$COORDINATE_FILENAME
+mustache $tmpviewfile ext-src/packages/templates/Dependencies.mustache > ext-src/packages/$LOWER_CASE_FORMAT/$DEPENDENCIES_FILENAME
+mustache $tmpviewfile ext-src/packages/templates/Package.mustache > ext-src/packages/$LOWER_CASE_FORMAT/$PACKAGE_FILENAME
+
+rm "$tmpviewfile"


### PR DESCRIPTION
While following the steps in: CONTRIBUTING.md, I see the existing `variables.json` file was not using the provided "Format" name. I changed the script to substitute the "Format" name before mustache processing.

Please let me know if I'm totally off base.