### PR TITLE
Updating getWorkspaceRoot

### DIFF
--- a/ext-src/packages/PackageDependenciesHelper.ts
+++ b/ext-src/packages/PackageDependenciesHelper.ts
@@ -39,7 +39,7 @@ export class PackageDependenciesHelper {
     if (workspaceRoot === undefined) {
       throw new TypeError("No workspaces opened");
     }
-    return workspaceRoot[0].uri.path;
+    return workspaceRoot[0].uri.fsPath;
   }
 
   public static getExtensionPath(): string {


### PR DESCRIPTION
Updating getWorkspaceRoot to handle separator differences between platforms. Fixes issue #83.