### PR TITLE
Make Python work for Windows

### DIFF
--- a/ext-src/packages/pypi/PyPiUtils.ts
+++ b/ext-src/packages/pypi/PyPiUtils.ts
@@ -17,14 +17,14 @@
 import { exec } from "../../utils/exec";
 import { PackageDependenciesHelper } from "../PackageDependenciesHelper";
 import { PyPIPackage } from './PyPIPackage';
-import * as os from 'os';
+import { type } from 'os';
 
 export class PyPiUtils {
   public async getDependencyArray(): Promise<Array<PyPIPackage>> {
     const WINDOWS = "Windows_NT"
     try {
       let command: string = "cat requirements.txt"
-      if (os.type() === WINDOWS) {
+      if (type() === WINDOWS) {
         command = "type requirements.txt"
       }
       let {stdout, stderr } = await exec(command, {

--- a/ext-src/packages/pypi/PyPiUtils.ts
+++ b/ext-src/packages/pypi/PyPiUtils.ts
@@ -17,11 +17,17 @@
 import { exec } from "../../utils/exec";
 import { PackageDependenciesHelper } from "../PackageDependenciesHelper";
 import { PyPIPackage } from './PyPIPackage';
+import * as os from 'os';
 
 export class PyPiUtils {
   public async getDependencyArray(): Promise<Array<PyPIPackage>> {
+    const WINDOWS = "Windows_NT"
     try {
-      let {stdout, stderr } = await exec(`cat requirements.txt`, {
+      let command: string = "cat requirements.txt"
+      if (os.type() === WINDOWS) {
+        command = "type requirements.txt"
+      }
+      let {stdout, stderr } = await exec(command, {
         cwd: PackageDependenciesHelper.getWorkspaceRoot(),
         env: {
           PATH: process.env.PATH


### PR DESCRIPTION
Basically, on Windows we don't have `cat`, so on the advice of some users, use `type`