### PR TITLE
Add PHP Composer #94

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,7 @@ yarn-error.log*
 .circleci/local-config.yml
 
 *.vsix
+
+# samples
+composer.lock
+libraries/

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Scan your libraries against either the free [OSS Index](https://ossindex.sonatyp
 
 ## Features
 
-- Scan npm, Maven, RubyGems, Go (`dep` and `go mod`), R (see known quirks) or PyPi projects (Go is only supported on Linux or OS/X)
+- Scan npm, Maven, RubyGems, Go (`dep` and `go mod`), PHP Composer, R (see known quirks) or PyPi projects (Go is only supported on Linux or OS/X)
 - See all components, with vulnerable ones highlighted
 
 ### Sonatype Nexus IQ Scan
@@ -49,6 +49,11 @@ We try and use other tooling whenever possible, to avoid reinventing the wheel (
 - If we are unable to parse your dependencies, it's likely one of those commands is throwing an error, and you should make sure it isn't.
 - Projects that use both `npm` and `yarn` can be confusing to a program, as we have to pick one to work with. If you experience issues, bear this in mind, it's likely that you have both a `package-lock.json` and a `yarn.lock`, and our lil extension is going "OH NOES!" because one is out of date, etc...
 
+#### PHP Composer
+
+- PHP Composer support depends on the installation of PHP and Composer
+- We run `composer show` to get your dependency list
+
 #### RubyGems
 
 - Ruby Gems support depends on the installation of Ruby, and Bundler
@@ -79,7 +84,7 @@ We try and use other tooling whenever possible, to avoid reinventing the wheel (
 - The way the R script runs, it finds all of the packages you've installed in the R environment, so not just for your project. This is because there is really no way to query for project specific packages, and appears to be a limitation of R.
 
 #### Various and Sundry
-`
+
 - Projects with both RubyGems and NPM (`Gemfile.lock` and `package.json`), or similar, this VS Code extension currently picks one format, and scans for it. We haven't built a path to scan multiple types in one project, but that would be lovely. PRs welcome :)
 
 - "My project has 3,000 dependencies, why is this so slow?!?". We chunk up requests to OSS Index (free solution) in sections of 128 dependencies, so for 3,000 dependencies, you are making 24 https POST requests for information, and then it's merging those results, etc... We'd love to know your feedback on the tool, so if you do run into this, open up an issue and let us know! Same goes for IQ Server, there could be quite a bit to process.

--- a/ext-src/packages/ComponentContainer.ts
+++ b/ext-src/packages/ComponentContainer.ts
@@ -18,6 +18,9 @@ import { MavenDependencies } from "./maven/MavenDependencies";
 import { NpmDependencies } from "./npm/NpmDependencies";
 import { GolangDependencies } from "./golang/GolangDependencies";
 import { PyPIDependencies } from "./pypi/PyPIDependencies";
+import { ComposerDependencies } from "./composer/ComposerDependencies";
+
+
 import { RequestService } from "../services/RequestService";
 
 export class ComponentContainer {
@@ -30,6 +33,7 @@ export class ComponentContainer {
     this.Implementation.push(new NpmDependencies(this.requestService));
     this.Implementation.push(new GolangDependencies(this.requestService));
     this.Implementation.push(new PyPIDependencies(this.requestService));
+    this.Implementation.push(new ComposerDependencies(this.requestService));
 
     // Bit of an odd side effect, if a project has multiple dependency types, the PackageMuncher will get set to the last one it encounters currently
     this.Implementation.forEach(i => {

--- a/ext-src/packages/LiteComponentContainer.ts
+++ b/ext-src/packages/LiteComponentContainer.ts
@@ -21,6 +21,7 @@ import { GolangLiteDependencies } from "./golang/GolangLiteDependencies";
 import { MavenLiteDependencies } from "./maven/MavenLiteDependencies";
 import { RubyGemLiteDependencies } from "./rubygems/RubyGemsLiteDependencies";
 import { RLiteDependencies } from "./r/RLiteDependencies";
+import { ComposerLiteDependencies } from "./composer/ComposerLiteDependencies";
 
 export class LiteComponentContainer {
   Implementation: Array<LitePackageDependencies> = [];
@@ -34,6 +35,8 @@ export class LiteComponentContainer {
     this.Implementation.push(new GolangLiteDependencies());
     this.Implementation.push(new MavenLiteDependencies());
     this.Implementation.push(new RLiteDependencies());
+    this.Implementation.push(new ComposerLiteDependencies());
+    
 
     // Bit of an odd side effect, if a project has multiple dependency types, the PackageMuncher will get set to the last one it encounters currently
     this.Implementation.forEach(i => {

--- a/ext-src/packages/composer/ComposerCoordinate.ts
+++ b/ext-src/packages/composer/ComposerCoordinate.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2019-present Sonatype, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export class ComposerCoordinate implements CoordinateType {
+  Name: string;
+  Version: string;
+
+  constructor(
+    name: string,
+    version: string, 
+  ) {
+    this.Name = name;
+    this.Version = version; 
+  }
+
+  public asCoordinates(): string {
+    return `${this.Name} - ${this.Version}`;
+  }
+}

--- a/ext-src/packages/composer/ComposerDependencies.ts
+++ b/ext-src/packages/composer/ComposerDependencies.ts
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2019-present Sonatype, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import * as _ from "lodash";
+
+import { ComposerPackage } from "./ComposerPackage";
+import { PackageDependencies } from "../PackageDependencies";
+import { ComponentEntry } from "../../models/ComponentEntry";
+import { ComposerCoordinate } from "./ComposerCoordinate";
+import { PackageDependenciesHelper } from "../PackageDependenciesHelper";
+import { RequestService } from "../../services/RequestService";
+import { ComposerUtils } from "./ComposerUtils";
+import { ScanType } from "../../types/ScanType";
+
+export class ComposerDependencies
+  extends PackageDependenciesHelper
+  implements PackageDependencies {
+  Dependencies: Array<ComposerPackage> = [];
+  CoordinatesToComponents: Map<string, ComponentEntry> = new Map<
+    string,
+    ComponentEntry
+  >();
+  RequestService: RequestService;
+
+  constructor(private requestService: RequestService) {
+    super();
+    this.RequestService = this.requestService;
+  }
+
+  public CheckIfValid(): boolean {
+    if (
+      PackageDependenciesHelper.doesPathExist(
+        PackageDependenciesHelper.getWorkspaceRoot(),
+        "composer.json"
+      )
+    ) {
+      console.debug("Valid for PHP Composer");
+      return true;
+    }
+    return false;
+  }
+
+  public ConvertToComponentEntry(resultEntry: any): string {
+    let coordinates = new ComposerCoordinate(
+      resultEntry.component.componentIdentifier.coordinates.namespace + '/' + resultEntry.component.componentIdentifier.coordinates.name,
+      resultEntry.component.componentIdentifier.coordinates.version
+    );
+
+    return coordinates.asCoordinates();
+  }
+
+  public convertToNexusFormat() {
+    return {
+      components: _.map(this.Dependencies, (d) => ({
+        packageUrl: d.toPurl() ,
+      })),
+    };
+  }
+
+  public toComponentEntries(data: any): Array<ComponentEntry> {
+    let components = new Array<ComponentEntry>();
+    for (let entry of data.components) {
+      const purl: string = entry.packageUrl;
+      const parts: string[] = purl.substr(13, purl.length).split("@");
+      const packageId = parts[0];
+
+      const version: string = parts[1].split("?")[0];
+
+      let componentEntry = new ComponentEntry(
+        packageId,
+        version,
+        ScanType.NexusIq
+      );
+      components.push(componentEntry);
+      let coordinates = new ComposerCoordinate(parts[0], version);
+      this.CoordinatesToComponents.set(
+        coordinates.asCoordinates(),
+        componentEntry
+      );
+    }
+    return components;
+  }
+
+  public async packageForIq(): Promise<any> {
+    try {
+      let composerUtils = new ComposerUtils();
+      this.Dependencies = await composerUtils.getDependencyArray();
+      Promise.resolve();
+    } catch (e) {
+      Promise.reject();
+    }
+  }
+}

--- a/ext-src/packages/composer/ComposerLiteDependencies.ts
+++ b/ext-src/packages/composer/ComposerLiteDependencies.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2019-present Sonatype, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { LitePackageDependencies } from "../LitePackageDependencies";
+import { ComposerPackage } from "./ComposerPackage";
+import { ComposerUtils } from './ComposerUtils';
+import { PackageDependenciesHelper } from "../PackageDependenciesHelper";
+
+export class ComposerLiteDependencies implements LitePackageDependencies {
+  dependencies: Array<ComposerPackage> = [];
+  format: string = "composer";
+  manifestName: string = "composer.lock";
+
+  public checkIfValid(): boolean {
+    return PackageDependenciesHelper.checkIfValid(this.manifestName, this.format);
+  }
+
+  public async packageForService(): Promise<any> {
+    try {
+      let composerUtils = new ComposerUtils();
+      this.dependencies = await composerUtils.getDependencyArray();
+
+      Promise.resolve();
+    }
+    catch (e) {
+      Promise.reject(e);
+    }
+  }
+}

--- a/ext-src/packages/composer/ComposerPackage.ts
+++ b/ext-src/packages/composer/ComposerPackage.ts
@@ -1,0 +1,36 @@
+
+/*
+ * Copyright (c) 2019-present Sonatype, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { PackageType } from "../PackageType";
+
+export class ComposerPackage implements PackageType {
+  constructor(
+    readonly Name: string,
+    readonly Version: string
+  ) {}
+
+  public toCoordinates() {
+    return `${this.Name}:${this.Version}`;
+  }
+
+  public toPurl() {
+    return `pkg:composer/${this.Name}@${this.Version}`;
+  }
+
+  public toCoordValueType(): string {
+    return `${this.Name} - ${this.Version}`;
+  }
+}

--- a/ext-src/packages/composer/ComposerUtils.ts
+++ b/ext-src/packages/composer/ComposerUtils.ts
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2019-present Sonatype, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { exec } from "../../utils/exec";
+import { PackageDependenciesHelper } from "../PackageDependenciesHelper";
+import { ComposerPackage } from './ComposerPackage';
+
+const COMPOSER_SHOW_COMMAND = "composer show";
+
+export class ComposerUtils {
+  public async getDependencyArray(): Promise<Array<ComposerPackage>> {
+    console.debug(`running '${COMPOSER_SHOW_COMMAND}'`);
+    try {
+      let { stdout, stderr } = await exec(COMPOSER_SHOW_COMMAND, {
+        cwd: PackageDependenciesHelper.getWorkspaceRoot()
+      });
+
+      if (stdout != "" && stderr === "") {
+        return Promise.resolve(this.parseComposerInstall(stdout));
+      } else {
+        return Promise.reject(
+          new Error(
+            "Error occurred in generating dependency list. Check that you have Composer installed"
+          )
+        );
+      }
+    } catch (e) {
+      return Promise.reject(
+        `"composer show" failed, try running it manually to see what went wrong: ${e.error}`
+      );
+    }
+  }
+
+  private parseComposerInstall(dependencyTree: string): Array<ComposerPackage> {
+    const dependencies: string = dependencyTree;
+    console.debug(dependencies);
+    console.debug(
+      "------------------------------------------------------------------------------"
+    );
+    let dependencyList: ComposerPackage[] = [];
+
+    const dependencyLines = dependencies.split("\n");
+    dependencyLines.forEach((dep) => {
+      if (dep.trim()) {
+        let dependencyParts: string[] = dep.replace(/\s{2,}/g,' ').trim().split(" ");
+        const name: string = dependencyParts[0];
+        const version: string = dependencyParts[1];
+        if (name && version) {
+          const dependencyObject: ComposerPackage = new ComposerPackage(
+            name,
+            version
+          );
+          dependencyList.push(dependencyObject);
+        } else {
+          console.warn(
+            "Skipping dependency: " +
+              dep +
+              " due to missing data (name, version)"
+          );
+        }
+      }
+    });
+
+    return dependencyList;
+  }
+}

--- a/sample/php-composer/README.txt
+++ b/sample/php-composer/README.txt
@@ -1,0 +1,4 @@
+1. install Composer https://getcomposer.org/
+2. run: composer install
+
+extension will run: composer show

--- a/sample/php-composer/composer.json
+++ b/sample/php-composer/composer.json
@@ -1,0 +1,25 @@
+{
+    "name": "test/project",
+    "type": "project",
+    "description": "Sample PHP Composer project",
+    "keywords": ["joomla", "cms"],
+    "config": {
+        "optimize-autoloader": true,
+        "platform": {
+            "php": "5.3.10"
+        },
+        "vendor-dir": "libraries/vendor"
+    },
+    "require": {
+        "php": ">=5.3.10",
+        "ircmaxell/password-compat": "1.*",
+        "leafo/lessphp": "0.5.0",
+        "paragonie/random_compat": "~1.4",
+        "paragonie/sodium_compat": "~1.6",
+        "phpmailer/phpmailer": "5.2.20",
+        "google/recaptcha": "^1.1"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^4.8.35"
+    }
+}

--- a/sample/python/requirements.txt
+++ b/sample/python/requirements.txt
@@ -1,0 +1,16 @@
+Werkzeug==0.16.0
+Django==2.2.6
+django-enumfields==1.0.0
+django-admin-ip-restrictor==2.1.1
+django-jsonfallback==2.1.2
+django-storages==1.7.2
+django-extensions==2.2.5
+django-decorator-include==2.1
+django-sequences==2.4
+django-reversion==3.0.7
+pytz==2019.3
+python-dateutil==2.8.0
+python-dotenv[cli]==0.10.3
+requests==2.22.0
+dpath==2.0.1
+protobuf==3.10.0


### PR DESCRIPTION
current implementation of PHP Composer support works: it displays list of dependencies, with violations
Then it seems basically ok to use.

there is still one little issue when opening a component: list of versions does not display

IMHO not a blocker