### PR TITLE
Trim trailing slash on construction of IQRequestService

### DIFF
--- a/ext-src/services/IqRequestService.ts
+++ b/ext-src/services/IqRequestService.ts
@@ -24,11 +24,16 @@ export class IqRequestService implements RequestService {
   applicationId: string = "";
 
   constructor(
-    readonly url: string,
+    private url: string,
     private user: string,
     private password: string,
     private getmaximumEvaluationPollAttempts: number
-  ) {}
+  ) 
+  {
+    if (url.endsWith("/")) {
+      this.url = url.replace(/\/$/, "");
+    }
+  }
 
   public setPassword(password: string) {
     this.password = password;


### PR DESCRIPTION
Fixes a situation where a user has a trailing slash for their IQ Server URL 

Fixes #122 