### PR TITLE
Add in ability to publish to Open VSX

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,6 +48,9 @@ jobs:
       - run: 
           name: Publish to Visual Studio Code Extension Marketplace
           command: vsce publish -p $VSCODE_TOKEN
+      - run:
+          name: Publish to Open VSX
+          command: npx ovsx publish -p $VSX_TOKEN
 
 workflows:
   version: 2.1

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ yarn-error.log*
 
 # ci config for local ci build
 .circleci/local-config.yml
+
+*.vsix


### PR DESCRIPTION
@Iletee showed me Open VSX earlier today, and it's basically a registry for VS Code compatible extensions. I promised him I would get this done in ten minutes, so here I am!

- Adds build step to publish to Open VSX
- Adds Environment Variable to CircleCI (Done)
- Adds .vsix files to gitignore (noticed they weren't ignored while I fiddled with commands locally)

