### PR TITLE
normalize Python package name to lowercase #127

### DIFF
--- a/ext-src/packages/pypi/PyPiUtils.ts
+++ b/ext-src/packages/pypi/PyPiUtils.ts
@@ -75,7 +75,7 @@ export class PyPiUtils {
             // artifactId, extension, and version are required fields. If a single dependency is missing any of the three, IQ will return a 400 response for the whole list
           if (name && version) {
             const dependencyObject: PyPIPackage = new PyPIPackage(
-              name,
+              name.toLowerCase(),
               version,
               extension,
               qualifier


### PR DESCRIPTION
when `requirements.txt` lists a package with some uppercase letter, it causes confusion with the reference package names which are full lowercase

normalizing to lowercase from the start removes the confusion