### PR TITLE
rename properties to get more natural order #135

### DIFF
--- a/ext-src/models/IqComponentModel.ts
+++ b/ext-src/models/IqComponentModel.ts
@@ -41,14 +41,14 @@ export class IqComponentModel implements ComponentModel {
     constructor(
       options: ComponentModelOptions
     ) {
-      this.dataSourceType = configuration.get("nexusExplorer.dataSource", "ossindex");
-      let url = configuration.get("nexusIQ.serverUrl") + "";
-      let username = configuration.get("nexusIQ.username") + "";
+      this.dataSourceType = options.configuration.get("nexusExplorer.dataSource", "ossindex");
+      let url = options.configuration.get("nexusIQ.serverUrl") + "";
+      let username = options.configuration.get("nexusIQ.username") + "";
       let maximumEvaluationPollAttempts = parseInt(
-        configuration.get("nexusIQ.maximumEvaluationPollAttempts") + "", 10);
-      this.applicationPublicId = configuration.get("nexusIQ.applicationId") + "";
-      let password = configuration.get("nexusIQ.userPassword") + "";
-      let strictSSL = configuration.get("nexusIQ.strictSSL") as boolean;
+        options.configuration.get("nexusIQ.maximumEvaluationPollAttempts") + "", 10);
+      this.applicationPublicId = options.configuration.get("nexusIQ.applicationId") + "";
+      let password = options.configuration.get("nexusIQ.userPassword") + "";
+      let strictSSL = options.configuration.get("nexusIQ.strictSSL") as boolean;
       this.requestService = new IqRequestService(url, username, password, maximumEvaluationPollAttempts, strictSSL, options.logger);
       this.logger = options.logger;
     }

--- a/ext-src/models/IqComponentModel.ts
+++ b/ext-src/models/IqComponentModel.ts
@@ -37,13 +37,13 @@ export class IqComponentModel implements ComponentModel {
     ) {
       
       this.dataSourceType = configuration.get("nexusExplorer.dataSource", "ossindex");
-      let url = configuration.get("nexusiq.url") + "";
-      let username = configuration.get("nexusiq.username") + "";
+      let url = configuration.get("nexusIQ.serverUrl") + "";
+      let username = configuration.get("nexusIQ.username") + "";
       let maximumEvaluationPollAttempts = parseInt(
-        configuration.get("nexusiq.maximumEvaluationPollAttempts") + "", 10);
-      this.applicationPublicId = configuration.get("nexusiq.applicationPublicId") + "";
-      let password = configuration.get("nexusiq.password") + "";
-      let strictSSL = configuration.get("nexusiq.strictSSL") as boolean;
+        configuration.get("nexusIQ.maximumEvaluationPollAttempts") + "", 10);
+      this.applicationPublicId = configuration.get("nexusIQ.applicationId") + "";
+      let password = configuration.get("nexusIQ.userPassword") + "";
+      let strictSSL = configuration.get("nexusIQ.strictSSL") as boolean;
       this.requestService = new IqRequestService(url, username, password, maximumEvaluationPollAttempts, strictSSL);
     }
   

--- a/package.json
+++ b/package.json
@@ -139,35 +139,35 @@
         "type": "object",
         "title": "Sonatype Nexus IQ configuration",
         "properties": {
-          "nexusiq.url": {
+          "nexusIQ.applicationId": {
+            "type": "string",
+            "default": "sandbox-application",
+            "description": "Your Nexus IQ Application Id"
+          },
+          "nexusIQ.maximumEvaluationPollAttempts": {
+            "type": "number",
+            "default": "300",
+            "description": "Number of retries (every 2secs) to wait for the evaluation report"
+          },
+          "nexusIQ.serverUrl": {
             "type": "string",
             "default": "http://127.0.0.1:8070",
-            "description": "URL including port of the Nexus IQ server"
+            "description": "URL (including port) of the Nexus IQ Server"
           },
-          "nexusiq.username": {
+          "nexusIQ.strictSSL": {
+            "type": "boolean",
+            "default": true,
+            "description": "Set this to false if you are using self signed certificates with Nexus IQ Server"
+          },
+          "nexusIQ.username": {
             "type": "string",
             "default": "admin",
             "description": "Your Nexus IQ user name"
           },
-          "nexusiq.password": {
+          "nexusIQ.userPassword": {
             "type": "string",
             "default": "admin123",
             "description": "Your Nexus IQ password"
-          },
-          "nexusiq.applicationPublicId": {
-            "type": "string",
-            "default": "sandbox-application",
-            "description": "Your Nexus IQ Application Public Id"
-          },
-          "nexusiq.maximumEvaluationPollAttempts": {
-            "type": "number",
-            "default": "300",
-            "description": "Number of retries (every 2secs) to wait for the Evaluation report. "
-          },
-          "nexusiq.strictSSL": {
-            "type": "boolean",
-            "default": true,
-            "description": "Set this to false if you are using self signed certificates with Nexus IQ Server."
           }
         }
       }


### PR DESCRIPTION
the new order will be much more natural (see #135):
1. Application Id
2. Maximum Evaluation Poll Attempts
3. Server Url
4. Strict SSL
5. Username
6. User Password

(compromise found to have alphabetical ordering that gives sufficient natural order for end user understanding)

I know this change will empty existing configurations to default values for new properties (Server Url and User Password, which replace previous Url and Password), but I really think the new experience is worth that