### PR TITLE
Kill request

### DIFF
--- a/ext-src/NexusExplorer.ts
+++ b/ext-src/NexusExplorer.ts
@@ -143,7 +143,7 @@ export class NexusExplorer {
     context.subscriptions.push(_channel);
 
     this.logger = new Logger({outputChannel: _channel});
-    this.logger.setLogLevel(LogLevel.TRACE);
+    this.logger.setLogLevel(LogLevel.ERROR);
 
     if (
       configuration.get("nexusExplorer.dataSource", "ossindex") + "" ==

--- a/ext-src/models/IqComponentModel.ts
+++ b/ext-src/models/IqComponentModel.ts
@@ -50,7 +50,7 @@ export class IqComponentModel implements ComponentModel {
       this.applicationPublicId = options.configuration.get("nexusiq.applicationPublicId") + "";
       let password = options.configuration.get("nexusiq.password") + "";
       let strictSSL = options.configuration.get("nexusiq.strictSSL") as boolean;
-      this.requestService = new IqRequestService(url, username, password, maximumEvaluationPollAttempts, strictSSL);
+      this.requestService = new IqRequestService(url, username, password, maximumEvaluationPollAttempts, strictSSL, options.logger);
       this.logger = options.logger;
     }
   

--- a/ext-src/models/OssIndexComponentModel.ts
+++ b/ext-src/models/OssIndexComponentModel.ts
@@ -37,7 +37,7 @@ export class OssIndexComponentModel implements ComponentModel {
     let username = options.configuration.get("ossindex.username") + "";
     let password = options.configuration.get("ossindex.password") + "";
     this.logger = options.logger;
-    this.requestService = new OssIndexRequestService(username, password);
+    this.requestService = new OssIndexRequestService(username, password, options.logger);
   }
   
   public evaluateComponents(): Promise<any> {

--- a/ext-src/services/IqRequestService.ts
+++ b/ext-src/services/IqRequestService.ts
@@ -42,11 +42,7 @@ export class IqRequestService implements RequestService {
     }
     this.logger.log(LogLevel.TRACE, `Creating new IQ Request Service`, url);
 
-    let https: boolean = false;
-    if (url.startsWith('https')) {
-      https = true;
-    }
-    this.agent = this.getAgent(this.strictSSL, https);
+    this.agent = this.getAgent(this.strictSSL, url.startsWith('https'));
   }
 
   public setPassword(password: string) {

--- a/ext-src/services/IqRequestService.ts
+++ b/ext-src/services/IqRequestService.ts
@@ -41,11 +41,12 @@ export class IqRequestService implements RequestService {
       this.url = url.replace(/\/$/, "");
     }
     let parts: URL = new URL(url);
-    let https: boolean = false;
-    if (parts.protocol === 'https' && parts.port != "") {
-      https = true;
+    this.logger.log(LogLevel.TRACE, `Creating new IQ Request Service`, parts);
+    let strictHttps: boolean = false;
+    if (parts.protocol === 'https' && parts.port === "443") {
+      strictHttps = true;
     }
-    this.agent = this.getAgent(this.strictSSL, https);
+    this.agent = this.getAgent(this.strictSSL, strictHttps);
   }
 
   public setPassword(password: string) {

--- a/ext-src/services/IqRequestService.ts
+++ b/ext-src/services/IqRequestService.ts
@@ -41,7 +41,7 @@ export class IqRequestService implements RequestService {
       this.url = url.replace(/\/$/, "");
     }
     let parts: URL = new URL(url);
-    this.logger.log(LogLevel.TRACE, `Creating new IQ Request Service`, parts);
+    this.logger.log(LogLevel.TRACE, `Creating new IQ Request Service`, parts.protocol, parts.port);
     let strictHttps: boolean = false;
     if (parts.protocol === 'https' && parts.port === "443") {
       strictHttps = true;

--- a/ext-src/services/IqRequestService.ts
+++ b/ext-src/services/IqRequestService.ts
@@ -64,9 +64,10 @@ export class IqRequestService implements RequestService {
   public getApplicationId(applicationPublicId: string): Promise<string> {
     this.logger.log(LogLevel.TRACE, `Getting application ID from public ID: ${applicationPublicId}`);
 
+    let url = `${this.url}/api/v2/applications?publicId=${applicationPublicId}`;
     return new Promise((resolve, reject) => {
       fetch(
-        `${this.url}/api/v2/applications?publicId=${applicationPublicId}`, 
+        url, 
         {
           method: 'GET',
           headers: this.getHeaders(),
@@ -76,8 +77,17 @@ export class IqRequestService implements RequestService {
             let json = await res.json();
             resolve(JSON.stringify(json));
           }
+          let body = await res.text();
+          this.logger.log(
+            LogLevel.TRACE, 
+            `Non 200 response from getting application ID`, url, body, res.status
+            );
           reject(res.status);
         }).catch((ex) => {
+          this.logger.log(
+            LogLevel.ERROR, 
+            `Error getting application ID from public ID`, url, ex
+            );
           reject(ex);
         });
     });
@@ -110,6 +120,10 @@ export class IqRequestService implements RequestService {
             );
           reject(res.status);
         }).catch((ex) => {
+          this.logger.log(
+            LogLevel.ERROR, 
+            `Error submitting to 3rd Party API`, ex
+            );
           reject(ex);
         });
     });

--- a/ext-src/services/IqRequestService.ts
+++ b/ext-src/services/IqRequestService.ts
@@ -13,14 +13,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import * as request from "request";
+import fetch from 'node-fetch';
+import { Headers } from 'node-fetch';
 import * as HttpStatus from 'http-status-codes';
 import { RequestService } from "./RequestService";
 import { RequestHelpers } from "./RequestHelpers";
-import { constants } from 'os';
+import { Agent as HttpsAgent }  from "https";
+import { Agent } from 'http';
+import { Logger, LogLevel } from '../utils/Logger';
 
 export class IqRequestService implements RequestService {
   readonly evaluationPollDelayMs = 2000;
+  private agent: Agent;
   applicationId: string = "";
 
   constructor(
@@ -28,9 +32,11 @@ export class IqRequestService implements RequestService {
     private user: string,
     private password: string,
     private getmaximumEvaluationPollAttempts: number,
-    private strictSSL: boolean = true
+    private strictSSL: boolean = true,
+    readonly logger: Logger
   ) 
   {
+    this.agent = this.getAgent(this.strictSSL);
     if (url.endsWith("/")) {
       this.url = url.replace(/\/$/, "");
     }
@@ -56,37 +62,23 @@ export class IqRequestService implements RequestService {
   }
 
   public getApplicationId(applicationPublicId: string): Promise<string> {
-    console.debug("getApplicationId", applicationPublicId);
+    this.logger.log(LogLevel.TRACE, `Getting application ID from public ID: ${applicationPublicId}`);
 
     return new Promise((resolve, reject) => {
-      request.get(
+      fetch(
+        `${this.url}/api/v2/applications?publicId=${applicationPublicId}`, 
         {
-          method: "GET",
-          url: `${this.url}/api/v2/applications?publicId=${applicationPublicId}`,
-          headers: RequestHelpers.getUserAgentHeader(),
-          strictSSL: this.strictSSL,
-          auth: { user: this.user, pass: this.password }
-        })
-        .on('response', (res) => {
-          console.log(res.statusCode);
-
-          if (res.statusCode != HttpStatus.OK) {            
-            reject(`Unable to retrieve Application ID. Could not communicate with server. Server error: ${res.statusCode}`);
-            return;
+          method: 'GET',
+          headers: this.getHeaders(),
+          agent: this.agent
+        }).then(async (res) => {
+          if (res.ok) {
+            let json = await res.json();
+            resolve(JSON.stringify(json));
           }
-
-          res.on('data', (data) => {
-            resolve(data);
-            return;
-          });
-        }).on('error', (err) => {
-          console.debug(err);
-          if (err.message.includes('ECONNREFUSED')) {
-            reject("Unable to reach Nexus IQ Server, please check that your config is correct, and that the server is reachable.");
-            return;
-          }
-          reject(err.message);
-          return;
+          reject(res.status);
+        }).catch((ex) => {
+          reject(ex);
         });
     });
   }
@@ -96,30 +88,22 @@ export class IqRequestService implements RequestService {
     applicationInternalId: string
   ): Promise<string> {
     return new Promise((resolve, reject) => {
-      request.post(
+      fetch(
+        `${this.url}/api/v2/evaluation/applications/${applicationInternalId}`, 
         {
-          method: "POST",
-          url: `${this.url}/api/v2/evaluation/applications/${applicationInternalId}`,
-          json: data,
-          strictSSL: this.strictSSL,
-          headers: RequestHelpers.getUserAgentHeader(),
-          auth: { user: this.user, pass: this.password }
-        },
-        (err: any, response: any, body: any) => {
-          if (err) {
-            reject(`Unable to perform IQ scan: ${err}`);
-            return;
+          method: 'POST',
+          agent: this.agent,
+          body: JSON.stringify(data),
+          headers: this.getHeadersWithApplicationJsonContentType()
+        }).then(async (res) => {
+          if(res.ok) {
+            let json = await res.json();
+            resolve(json.resultId);
           }
-          if (response.statusCode != HttpStatus.OK) {
-            reject(`Unable to perform IQ scan: ${body}`);
-            return;
-          }
-
-          let resultId = body.resultId;
-          resolve(resultId);
-          return;
-        }
-      );
+          reject(res.status);
+        }).catch((ex) => {
+          reject(ex);
+        });
     });
   }
 
@@ -187,61 +171,56 @@ export class IqRequestService implements RequestService {
     resolve: (body: string) => any,
     reject: (statusCode: number, message: string) => any
   ) {
-    request.get(
+    fetch(
+      `${this.url}/api/v2/evaluation/applications/${applicationInternalId}/results/${resultId}`, 
       {
-        method: "GET",
-        url: `${this.url}/api/v2/evaluation/applications/${applicationInternalId}/results/${resultId}`,
-        headers: RequestHelpers.getUserAgentHeader(),
-        strictSSL: this.strictSSL,
-        auth: { user: this.user, pass: this.password }
-      },
-      (error: any, response: any, body: any) => {
-        if (response && response.statusCode != HttpStatus.OK) {
-          reject(response.statusCode, error);
+        method: 'GET',
+        headers: this.getHeaders(),
+        agent: this.agent
+      }).then(async (res) => {
+        if (!res.ok) {
+          reject(res.status, 'uhh');
           return;
         }
-        if (error) {
-          reject(response.statusCode, error);
+        if (res.status == 404) {
+          reject(res.status, 'Polling');
           return;
         }
-        resolve(body);
-      }
-    );
+        let json = await res.json();
+        resolve(JSON.stringify(json));
+      }).catch((ex) => {
+        reject(ex, 'big issue');
+      });
   }
 
   public async getRemediation(nexusArtifact: any) {
     return new Promise((resolve, reject) => {
-      console.debug("begin getRemediation", nexusArtifact);
+      this.logger.log(LogLevel.TRACE, `Begin Get Remediation`);
       var requestdata = nexusArtifact.component;
-      console.debug("requestdata", requestdata);
+      this.logger.log(LogLevel.TRACE, `Begin Sending Request Data`);
       let url = `${this.url}/api/v2/components/remediation/application/${this.applicationId}`;
 
-      request.post(
+      fetch(
+        url, 
         {
-          method: "post",
-          json: requestdata,
-          url: url,
-          headers: RequestHelpers.getUserAgentHeader(),
-          strictSSL: this.strictSSL,
-          auth: { user: this.user, pass: this.password }
-        },
-        (err, response, body) => {
-          if (err) {
-            reject(`Unable to retrieve Component details: ${err}`);
-            return;
+          method: 'POST',
+          headers: this.getHeadersWithApplicationJsonContentType(),
+          body: JSON.stringify(requestdata),
+          agent: this.agent
+        }).then(async (res) => {
+          if (res.ok) {
+            resolve(await res.json());
           }
-          console.debug("response", response);
-          console.debug("body", body);
-          resolve(body);
-        }
-      );
+          reject(res.status);
+        }).catch((ex) => {
+          reject(ex);
+        });
     });
   }
 
   public async getCVEDetails(cve: any, nexusArtifact: any) {
-    //, settings) {
     return new Promise((resolve, reject) => {
-      console.log("begin GetCVEDetails", cve, nexusArtifact);
+      this.logger.log(LogLevel.TRACE, `Begin Get CVE Details`);
       let timestamp = Date.now();
       let hash = nexusArtifact.component.hash;
       let componentIdentifier = this.encodeComponentIdentifier(
@@ -255,30 +234,20 @@ export class IqRequestService implements RequestService {
       }
       let url = `${this.url}/rest/vulnerability/details/${vulnerability_source}/${cve}?componentIdentifier=${componentIdentifier}&hash=${hash}&timestamp=${timestamp}`;
 
-      request.get(
+      fetch(
+        url,
         {
-          method: "GET",
-          url: url,
-          headers: RequestHelpers.getUserAgentHeader(),
-          strictSSL: this.strictSSL,
-          auth: {
-            user: this.user,
-            pass: this.password
+          method: 'GET',
+          headers: this.getHeaders(),
+          agent: this.agent
+        }).then(async (res) => {
+          if (res.ok) {
+            resolve(await res.json());
           }
-        },
-        (err, response, body) => {
-          if (err) {
-            reject(`Unable to retrieve CVEData: ${err}`);
-            return;
-          }
-          console.debug("response", response);
-          console.debug("body", body);
-
-          let resp = JSON.parse(body) as any;
-
-          resolve(resp);
-        }
-      );
+          reject(res.status);
+        }).catch((ex) => {
+          reject(ex);
+        });
     });
   }
 
@@ -301,33 +270,26 @@ export class IqRequestService implements RequestService {
         `hash=${hash}&matchState=${matchstate}&` +
         `timestamp=${timestamp}&proprietary=false`;
 
-      request.get(
+      fetch(
+        url,
         {
-          method: "GET",
-          url: url,
-          headers: RequestHelpers.getUserAgentHeader(),
-          strictSSL: this.strictSSL,
-          auth: {
-            user: this.user,
-            pass: this.password
+          method: 'GET', 
+          headers: this.getHeaders(),
+          agent: this.agent
+        }).then(async (res) => {
+          if (res.ok) {
+            resolve(await res.json());
           }
-        },
-        (err, response, body) => {
-          if (err) {
-            reject(`Unable to retrieve GetAllVersions: ${err}`);
-            return;
-          }
-          const versionArray = JSON.parse(body) as any[];
-          console.debug("getAllVersions retrieved body", versionArray);
-          resolve(versionArray);
-        }
-      );
+          reject(res.status);
+        }).catch((ex) => {
+          reject(ex);
+        });
     });
   }
 
   public async showSelectedVersion(componentIdentifier: any, version: string) {
     return new Promise((resolve, reject) => {
-      console.debug("begin showSelectedVersion", componentIdentifier, version);
+      this.logger.log(LogLevel.TRACE, `Begin Show Selected Version`);
       var transmittingComponentIdentifier = { ...componentIdentifier };
 
       transmittingComponentIdentifier.coordinates = {
@@ -345,33 +307,57 @@ export class IqRequestService implements RequestService {
       };
       let url = `${this.url}/api/v2/components/details`;
 
-      request.post(
+      fetch(
+        url,
         {
-          method: "post",
-          json: detailsRequest,
-          url: url,
-          headers: RequestHelpers.getUserAgentHeader(),
-          strictSSL: this.strictSSL,
-          auth: {
-            user: this.user,
-            pass: this.password
+          method: 'POST',
+          headers: this.getHeadersWithApplicationJsonContentType(),
+          body: JSON.stringify(detailsRequest),
+          agent: this.agent
+        }).then(async (res) => {
+          if (res.ok) {
+            resolve(await res.json());
           }
-        },
-        (err, response, body) => {
-          if (err) {
-            reject(`Unable to retrieve selected version details: ${err}`);
-            return;
-          }
-
-          resolve(body);
-        }
-      );
+          reject(res.status);
+        }).catch((ex) => {
+          reject(ex);
+        });
     });
   }
 
   private encodeComponentIdentifier(componentIdentifier: string) {
     let actual = encodeURIComponent(JSON.stringify(componentIdentifier));
-    console.log("actual", actual);
+    this.logger.log(LogLevel.TRACE, `Actual: ${actual}`); 
     return actual;
+  }
+
+  private getHeadersWithApplicationJsonContentType(): Headers {
+    const headers = this.getHeaders();
+
+    headers.append('Content-Type', 'application/json');
+
+    return headers;
+  }
+
+  private getHeaders(): Headers {
+    const meta = RequestHelpers.getUserAgentHeader();
+
+    const headers = new Headers(meta);
+    headers.append('Authorization', this.getBasicAuth());
+
+    return headers;
+  }
+
+  private getBasicAuth(): string {
+    return `Basic ${Buffer.from(`${this.user}:${this.password}`).toString('base64')}`;
+  }
+
+  private getAgent(strictSSL: boolean): Agent {
+    if (!strictSSL) {
+      return new HttpsAgent({
+        rejectUnauthorized: strictSSL
+      });
+    }
+    return new Agent();
   }
 }

--- a/ext-src/services/IqRequestService.ts
+++ b/ext-src/services/IqRequestService.ts
@@ -40,13 +40,13 @@ export class IqRequestService implements RequestService {
     if (url.endsWith("/")) {
       this.url = url.replace(/\/$/, "");
     }
-    let parts: URL = new URL(url);
-    this.logger.log(LogLevel.TRACE, `Creating new IQ Request Service`, parts.protocol, parts.port);
-    let strictHttps: boolean = false;
-    if (parts.protocol === 'https' && parts.port === "443") {
-      strictHttps = true;
+    this.logger.log(LogLevel.TRACE, `Creating new IQ Request Service`, url);
+
+    let https: boolean = false;
+    if (url.startsWith('https')) {
+      https = true;
     }
-    this.agent = this.getAgent(this.strictSSL, strictHttps);
+    this.agent = this.getAgent(this.strictSSL, https);
   }
 
   public setPassword(password: string) {

--- a/ext-src/services/IqRequestService.ts
+++ b/ext-src/services/IqRequestService.ts
@@ -21,7 +21,6 @@ import { RequestHelpers } from "./RequestHelpers";
 import { Agent as HttpsAgent }  from "https";
 import { Agent } from 'http';
 import { ILogger, LogLevel } from '../utils/Logger';
-import { URL } from 'url';
 
 export class IqRequestService implements RequestService {
   readonly evaluationPollDelayMs = 2000;

--- a/ext-src/services/OssIndexRequestService.ts
+++ b/ext-src/services/OssIndexRequestService.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import fetch from 'node-fetch';
-import {Headers} from 'node-fetch';
+import { Headers } from 'node-fetch';
 import { Logger, LogLevel } from '../utils/Logger';
 
 import { LiteRequestService } from "./LiteRequestService";
@@ -50,7 +50,7 @@ export class OssIndexRequestService implements LiteRequestService {
       for (var purlList of newPurls) {
         let err, res = await this.callOssIndex(purlList);
         if (err != null) {
-          this.logger.log(LogLevel.ERROR, 'Uh oh', err);
+          this.logger.log(LogLevel.ERROR, 'Uh oh');
           reject(err);
         } else {
           response = response.concat(res);
@@ -70,7 +70,7 @@ export class OssIndexRequestService implements LiteRequestService {
   private async callOssIndex(purls: String[]): Promise<any> {
     const headers = new Headers(RequestHelpers.getUserAgentHeader());
     headers.append('Content-Type', 'application/json');
-    this.logger.log(LogLevel.TRACE, "Got User Agent", headers);
+    this.logger.log(LogLevel.TRACE, "Got User Agent");
 
     return new Promise((resolve, reject) => {
       fetch(URL,

--- a/ext-src/services/OssIndexRequestService.ts
+++ b/ext-src/services/OssIndexRequestService.ts
@@ -13,8 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import * as request from "request";
-import * as HttpStatus from "http-status-codes";
+import fetch from 'node-fetch';
+import {Headers} from 'node-fetch';
+import { Logger, LogLevel } from '../utils/Logger';
 
 import { LiteRequestService } from "./LiteRequestService";
 import { RequestHelpers } from "./RequestHelpers";
@@ -25,7 +26,10 @@ const URL = `https://ossindex.sonatype.org/api/v3/component-report`;
 
 export class OssIndexRequestService implements LiteRequestService {
 
-  constructor(readonly username: string, private password: string){}
+  constructor(
+    readonly username: string, 
+    private password: string,
+    readonly logger: Logger) {}
 
   public isPasswordSet():boolean {
     if(this.password == "") {
@@ -46,6 +50,7 @@ export class OssIndexRequestService implements LiteRequestService {
       for (var purlList of newPurls) {
         let err, res = await this.callOssIndex(purlList);
         if (err != null) {
+          this.logger.log(LogLevel.ERROR, 'Uh oh', err);
           reject(err);
         } else {
           response = response.concat(res);
@@ -62,36 +67,32 @@ export class OssIndexRequestService implements LiteRequestService {
     })
   }
 
-  private async callOssIndex(purls: String[]) {
+  private async callOssIndex(purls: String[]): Promise<any> {
+    const headers = new Headers(RequestHelpers.getUserAgentHeader());
+    headers.append('Content-Type', 'application/json');
+    this.logger.log(LogLevel.TRACE, "Got User Agent", headers);
+
     return new Promise((resolve, reject) => {
-      request.post(
+      fetch(URL,
         {
-          method: "POST",
-          url: `${URL}`,
-          json: this.turnPurlsIntoOssIndexRequestObject(purls),
-          headers: RequestHelpers.getUserAgentHeader()
-        },
-        (err: any, response: any, body: any) => {
-          if (err) {            
-            reject(`Unable to retrieve Component Report: ${err}`);
-            return;
+          method: 'POST',
+          body: JSON.stringify(this.turnPurlsIntoOssIndexRequestObject(purls)),
+          headers: headers
+        }).then(async (res) => {
+          if (res.ok) {
+            resolve(await res.json());
           }
-          if (response.statusCode != HttpStatus.OK) {
-            reject(`Unable to retrieve Component Report. Could not communicate with server. Server error: ${response.statusCode}`);
-            return;
-          }
-          resolve(body);
-          return;
-        }
-      );
+          reject(res.status);
+        }).catch((ex) => {
+          reject(ex);
+        });
     });
   }
 
   private turnPurlsIntoOssIndexRequestObject(purls: String[]): any {
-    let components = {
+    return { 
       coordinates: purls
-    }
-    return components;
+    };
   }
 
   /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1202,9 +1202,8 @@
     },
     "@types/caseless": {
       "version": "0.12.2",
-      "resolved": "https://registry.npmjs.org/@types/caseless/-/caseless-0.12.2.tgz",
-      "integrity": "sha512-6ckxMjBBD8URvjB6J3NcnuAn5Pkl7t3TizAg+xdlzzQGSPSmBcXf8KoIH0ua/i+tio+ZRUHEXp0HEmvaR4kt0w==",
-      "dev": true
+      "resolved": "https://repo.sonatype.com/repository/npm-all/@types/caseless/-/caseless-0.12.2.tgz",
+      "integrity": "sha512-6ckxMjBBD8URvjB6J3NcnuAn5Pkl7t3TizAg+xdlzzQGSPSmBcXf8KoIH0ua/i+tio+ZRUHEXp0HEmvaR4kt0w=="
     },
     "@types/jest": {
       "version": "22.2.3",
@@ -1230,8 +1229,28 @@
     "@types/node": {
       "version": "12.19.11",
       "resolved": "https://repo.sonatype.com/repository/npm-all/@types/node/-/node-12.19.11.tgz",
-      "integrity": "sha512-bwVfNTFZOrGXyiQ6t4B9sZerMSShWNsGRw8tC5DY1qImUNczS9SjT4G6PnzjCnxsu5Ubj6xjL2lgwddkxtQl5w==",
-      "dev": true
+      "integrity": "sha512-bwVfNTFZOrGXyiQ6t4B9sZerMSShWNsGRw8tC5DY1qImUNczS9SjT4G6PnzjCnxsu5Ubj6xjL2lgwddkxtQl5w=="
+    },
+    "@types/node-fetch": {
+      "version": "2.5.7",
+      "resolved": "https://repo.sonatype.com/repository/npm-all/@types/node-fetch/-/node-fetch-2.5.7.tgz",
+      "integrity": "sha512-o2WVNf5UhWRkxlf6eq+jMZDu7kjgpgJfl4xVNlvryc95O/6F2ld8ztKX+qu+Rjyet93WAWm5LjeX9H5FGkODvw==",
+      "requires": {
+        "@types/node": "*",
+        "form-data": "^3.0.0"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "3.0.0",
+          "resolved": "https://repo.sonatype.com/repository/npm-all/form-data/-/form-data-3.0.0.tgz",
+          "integrity": "sha512-CKMFDglpbMi6PyN+brwB9Q/GOw0eAnsrEZDgcsH5Krhz5Od/haKHAX0NmQfha2zPPz0JpWzA7GJHGSnvCRLWsg==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        }
+      }
     },
     "@types/normalize-package-data": {
       "version": "2.4.0",
@@ -1273,10 +1292,9 @@
       }
     },
     "@types/request": {
-      "version": "2.48.3",
-      "resolved": "https://registry.npmjs.org/@types/request/-/request-2.48.3.tgz",
-      "integrity": "sha512-3Wo2jNYwqgXcIz/rrq18AdOZUQB8cQ34CXZo+LUwPJNpvRAL86+Kc2wwI8mqpz9Cr1V+enIox5v+WZhy/p3h8w==",
-      "dev": true,
+      "version": "2.48.5",
+      "resolved": "https://repo.sonatype.com/repository/npm-all/@types/request/-/request-2.48.5.tgz",
+      "integrity": "sha512-/LO7xRVnL3DxJ1WkPGDQrp4VTV1reX9RkC85mJ+Qzykj2Bdw+mG15aAfDahc76HtknjzE16SX/Yddn6MxVbmGQ==",
       "requires": {
         "@types/caseless": "*",
         "@types/node": "*",
@@ -1286,9 +1304,8 @@
       "dependencies": {
         "form-data": {
           "version": "2.5.1",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
+          "resolved": "https://repo.sonatype.com/repository/npm-all/form-data/-/form-data-2.5.1.tgz",
           "integrity": "sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==",
-          "dev": true,
           "requires": {
             "asynckit": "^0.4.0",
             "combined-stream": "^1.0.6",
@@ -1310,10 +1327,9 @@
       "dev": true
     },
     "@types/tough-cookie": {
-      "version": "2.3.5",
-      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-2.3.5.tgz",
-      "integrity": "sha512-SCcK7mvGi3+ZNz833RRjFIxrn4gI1PPR3NtuIS+6vMkvmsGjosqTJwRt5bAEFLRz+wtJMWv8+uOnZf2hi2QXTg==",
-      "dev": true
+      "version": "4.0.0",
+      "resolved": "https://repo.sonatype.com/repository/npm-all/@types/tough-cookie/-/tough-cookie-4.0.0.tgz",
+      "integrity": "sha512-I99sngh224D0M7XgW1s120zxCt3VYQ3IQsuw3P3jbq5GG4yc79+ZjyKznyOGIQrflfylLgcfekeZW/vk0yng6A=="
     },
     "@types/vscode": {
       "version": "1.23.0",
@@ -1576,6 +1592,7 @@
       "version": "6.10.2",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
       "integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
+      "dev": true,
       "requires": {
         "fast-deep-equal": "^2.0.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -2185,9 +2202,9 @@
       "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
     },
     "aws4": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
-      "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
+      "version": "1.11.0",
+      "resolved": "https://repo.sonatype.com/repository/npm-all/aws4/-/aws4-1.11.0.tgz",
+      "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA=="
     },
     "axobject-query": {
       "version": "2.0.2",
@@ -6052,7 +6069,8 @@
     "fast-deep-equal": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
+      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
+      "dev": true
     },
     "fast-glob": {
       "version": "2.2.7",
@@ -7836,12 +7854,30 @@
       "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
     },
     "har-validator": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
-      "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
+      "version": "5.1.5",
+      "resolved": "https://repo.sonatype.com/repository/npm-all/har-validator/-/har-validator-5.1.5.tgz",
+      "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
       "requires": {
-        "ajv": "^6.5.5",
+        "ajv": "^6.12.3",
         "har-schema": "^2.0.0"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "6.12.6",
+          "resolved": "https://repo.sonatype.com/repository/npm-all/ajv/-/ajv-6.12.6.tgz",
+          "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "fast-deep-equal": {
+          "version": "3.1.3",
+          "resolved": "https://repo.sonatype.com/repository/npm-all/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+          "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+        }
       }
     },
     "harmony-reflect": {
@@ -10713,6 +10749,11 @@
       "requires": {
         "lower-case": "^1.1.1"
       }
+    },
+    "node-fetch": {
+      "version": "2.6.1",
+      "resolved": "https://repo.sonatype.com/repository/npm-all/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
     },
     "node-forge": {
       "version": "0.10.0",
@@ -13692,9 +13733,9 @@
       }
     },
     "request": {
-      "version": "2.88.0",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
-      "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
+      "version": "2.88.2",
+      "resolved": "https://repo.sonatype.com/repository/npm-all/request/-/request-2.88.2.tgz",
+      "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
       "requires": {
         "aws-sign2": "~0.7.0",
         "aws4": "^1.8.0",
@@ -13703,7 +13744,7 @@
         "extend": "~3.0.2",
         "forever-agent": "~0.6.1",
         "form-data": "~2.3.2",
-        "har-validator": "~5.1.0",
+        "har-validator": "~5.1.3",
         "http-signature": "~1.2.0",
         "is-typedarray": "~1.0.0",
         "isstream": "~0.1.2",
@@ -13713,9 +13754,20 @@
         "performance-now": "^2.1.0",
         "qs": "~6.5.2",
         "safe-buffer": "^5.1.2",
-        "tough-cookie": "~2.4.3",
+        "tough-cookie": "~2.5.0",
         "tunnel-agent": "^0.6.0",
         "uuid": "^3.3.2"
+      },
+      "dependencies": {
+        "tough-cookie": {
+          "version": "2.5.0",
+          "resolved": "https://repo.sonatype.com/repository/npm-all/tough-cookie/-/tough-cookie-2.5.0.tgz",
+          "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+          "requires": {
+            "psl": "^1.1.28",
+            "punycode": "^2.1.1"
+          }
+        }
       }
     },
     "request-promise-core": {
@@ -15745,6 +15797,7 @@
       "version": "2.4.3",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
       "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
+      "dev": true,
       "requires": {
         "psl": "^1.1.24",
         "punycode": "^1.4.1"
@@ -15753,7 +15806,8 @@
         "punycode": {
           "version": "1.4.1",
           "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+          "dev": true
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1200,11 +1200,6 @@
         "popper.js": "^1.14.1"
       }
     },
-    "@types/caseless": {
-      "version": "0.12.2",
-      "resolved": "https://repo.sonatype.com/repository/npm-all/@types/caseless/-/caseless-0.12.2.tgz",
-      "integrity": "sha512-6ckxMjBBD8URvjB6J3NcnuAn5Pkl7t3TizAg+xdlzzQGSPSmBcXf8KoIH0ua/i+tio+ZRUHEXp0HEmvaR4kt0w=="
-    },
     "@types/jest": {
       "version": "22.2.3",
       "resolved": "https://registry.npmjs.org/@types/jest/-/jest-22.2.3.tgz",
@@ -1229,12 +1224,14 @@
     "@types/node": {
       "version": "12.19.11",
       "resolved": "https://repo.sonatype.com/repository/npm-all/@types/node/-/node-12.19.11.tgz",
-      "integrity": "sha512-bwVfNTFZOrGXyiQ6t4B9sZerMSShWNsGRw8tC5DY1qImUNczS9SjT4G6PnzjCnxsu5Ubj6xjL2lgwddkxtQl5w=="
+      "integrity": "sha512-bwVfNTFZOrGXyiQ6t4B9sZerMSShWNsGRw8tC5DY1qImUNczS9SjT4G6PnzjCnxsu5Ubj6xjL2lgwddkxtQl5w==",
+      "dev": true
     },
     "@types/node-fetch": {
       "version": "2.5.7",
       "resolved": "https://repo.sonatype.com/repository/npm-all/@types/node-fetch/-/node-fetch-2.5.7.tgz",
       "integrity": "sha512-o2WVNf5UhWRkxlf6eq+jMZDu7kjgpgJfl4xVNlvryc95O/6F2ld8ztKX+qu+Rjyet93WAWm5LjeX9H5FGkODvw==",
+      "dev": true,
       "requires": {
         "@types/node": "*",
         "form-data": "^3.0.0"
@@ -1244,6 +1241,7 @@
           "version": "3.0.0",
           "resolved": "https://repo.sonatype.com/repository/npm-all/form-data/-/form-data-3.0.0.tgz",
           "integrity": "sha512-CKMFDglpbMi6PyN+brwB9Q/GOw0eAnsrEZDgcsH5Krhz5Od/haKHAX0NmQfha2zPPz0JpWzA7GJHGSnvCRLWsg==",
+          "dev": true,
           "requires": {
             "asynckit": "^0.4.0",
             "combined-stream": "^1.0.8",
@@ -1291,29 +1289,6 @@
         "@types/react": "*"
       }
     },
-    "@types/request": {
-      "version": "2.48.5",
-      "resolved": "https://repo.sonatype.com/repository/npm-all/@types/request/-/request-2.48.5.tgz",
-      "integrity": "sha512-/LO7xRVnL3DxJ1WkPGDQrp4VTV1reX9RkC85mJ+Qzykj2Bdw+mG15aAfDahc76HtknjzE16SX/Yddn6MxVbmGQ==",
-      "requires": {
-        "@types/caseless": "*",
-        "@types/node": "*",
-        "@types/tough-cookie": "*",
-        "form-data": "^2.5.0"
-      },
-      "dependencies": {
-        "form-data": {
-          "version": "2.5.1",
-          "resolved": "https://repo.sonatype.com/repository/npm-all/form-data/-/form-data-2.5.1.tgz",
-          "integrity": "sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==",
-          "requires": {
-            "asynckit": "^0.4.0",
-            "combined-stream": "^1.0.6",
-            "mime-types": "^2.1.12"
-          }
-        }
-      }
-    },
     "@types/sizzle": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/@types/sizzle/-/sizzle-2.3.2.tgz",
@@ -1325,11 +1300,6 @@
       "resolved": "https://registry.npmjs.org/@types/tapable/-/tapable-1.0.2.tgz",
       "integrity": "sha512-42zEJkBpNfMEAvWR5WlwtTH22oDzcMjFsL9gDGExwF8X8WvAiw7Vwop7hPw03QT8TKfec83LwbHj6SvpqM4ELQ==",
       "dev": true
-    },
-    "@types/tough-cookie": {
-      "version": "4.0.0",
-      "resolved": "https://repo.sonatype.com/repository/npm-all/@types/tough-cookie/-/tough-cookie-4.0.0.tgz",
-      "integrity": "sha512-I99sngh224D0M7XgW1s120zxCt3VYQ3IQsuw3P3jbq5GG4yc79+ZjyKznyOGIQrflfylLgcfekeZW/vk0yng6A=="
     },
     "@types/vscode": {
       "version": "1.23.0",
@@ -2076,6 +2046,7 @@
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
       "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+      "dev": true,
       "requires": {
         "safer-buffer": "~2.1.0"
       }
@@ -2121,7 +2092,8 @@
     "assert-plus": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+      "dev": true
     },
     "assign-symbols": {
       "version": "1.0.0",
@@ -2165,7 +2137,8 @@
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+      "dev": true
     },
     "atob": {
       "version": "2.1.2",
@@ -2199,12 +2172,14 @@
     "aws-sign2": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
+      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
+      "dev": true
     },
     "aws4": {
       "version": "1.11.0",
       "resolved": "https://repo.sonatype.com/repository/npm-all/aws4/-/aws4-1.11.0.tgz",
-      "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA=="
+      "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==",
+      "dev": true
     },
     "axobject-query": {
       "version": "2.0.2",
@@ -2845,6 +2820,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
       "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+      "dev": true,
       "requires": {
         "tweetnacl": "^0.14.3"
       }
@@ -3267,7 +3243,8 @@
     "caseless": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+      "dev": true
     },
     "chalk": {
       "version": "2.4.2",
@@ -4218,6 +4195,7 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
       "requires": {
         "delayed-stream": "~1.0.0"
       }
@@ -4417,7 +4395,8 @@
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "dev": true
     },
     "cosmiconfig": {
       "version": "5.2.1",
@@ -4805,6 +4784,7 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "dev": true,
       "requires": {
         "assert-plus": "^1.0.0"
       }
@@ -5018,7 +4998,8 @@
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+      "dev": true
     },
     "depd": {
       "version": "1.1.2",
@@ -5287,6 +5268,7 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
       "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+      "dev": true,
       "requires": {
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.1.0"
@@ -6010,7 +5992,8 @@
     "extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "dev": true
     },
     "extend-shallow": {
       "version": "3.0.2",
@@ -6064,7 +6047,8 @@
     "extsprintf": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+      "dev": true
     },
     "fast-deep-equal": {
       "version": "2.0.1",
@@ -6395,7 +6379,8 @@
     "fast-json-stable-stringify": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
+      "dev": true
     },
     "fast-levenshtein": {
       "version": "2.0.6",
@@ -6626,7 +6611,8 @@
     "forever-agent": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+      "dev": true
     },
     "fork-ts-checker-webpack-plugin": {
       "version": "1.0.0-alpha.6",
@@ -6932,6 +6918,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
       "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+      "dev": true,
       "requires": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.6",
@@ -7660,6 +7647,7 @@
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "dev": true,
       "requires": {
         "assert-plus": "^1.0.0"
       }
@@ -7851,12 +7839,14 @@
     "har-schema": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
+      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+      "dev": true
     },
     "har-validator": {
       "version": "5.1.5",
       "resolved": "https://repo.sonatype.com/repository/npm-all/har-validator/-/har-validator-5.1.5.tgz",
       "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
+      "dev": true,
       "requires": {
         "ajv": "^6.12.3",
         "har-schema": "^2.0.0"
@@ -7866,6 +7856,7 @@
           "version": "6.12.6",
           "resolved": "https://repo.sonatype.com/repository/npm-all/ajv/-/ajv-6.12.6.tgz",
           "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+          "dev": true,
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "fast-json-stable-stringify": "^2.0.0",
@@ -7876,7 +7867,8 @@
         "fast-deep-equal": {
           "version": "3.1.3",
           "resolved": "https://repo.sonatype.com/repository/npm-all/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-          "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+          "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+          "dev": true
         }
       }
     },
@@ -8498,6 +8490,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+      "dev": true,
       "requires": {
         "assert-plus": "^1.0.0",
         "jsprim": "^1.2.2",
@@ -9044,7 +9037,8 @@
     "is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+      "dev": true
     },
     "is-utf8": {
       "version": "0.2.1",
@@ -9094,7 +9088,8 @@
     "isstream": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+      "dev": true
     },
     "istanbul-api": {
       "version": "1.3.7",
@@ -9810,7 +9805,8 @@
     "jsbn": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+      "dev": true
     },
     "jsdom": {
       "version": "11.12.0",
@@ -9874,12 +9870,14 @@
     "json-schema": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+      "dev": true
     },
     "json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true
     },
     "json-stable-stringify": {
       "version": "1.0.1",
@@ -9899,7 +9897,8 @@
     "json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+      "dev": true
     },
     "json3": {
       "version": "3.3.3",
@@ -9943,6 +9942,7 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
       "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "dev": true,
       "requires": {
         "assert-plus": "1.0.0",
         "extsprintf": "1.3.0",
@@ -10495,12 +10495,14 @@
     "mime-db": {
       "version": "1.42.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.42.0.tgz",
-      "integrity": "sha512-UbfJCR4UAVRNgMpfImz05smAXK7+c+ZntjaA26ANtkXLlOe947Aag5zdIcKQULAiF9Cq4WxBi9jUs5zkA84bYQ=="
+      "integrity": "sha512-UbfJCR4UAVRNgMpfImz05smAXK7+c+ZntjaA26ANtkXLlOe947Aag5zdIcKQULAiF9Cq4WxBi9jUs5zkA84bYQ==",
+      "dev": true
     },
     "mime-types": {
       "version": "2.1.25",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.25.tgz",
       "integrity": "sha512-5KhStqB5xpTAeGqKBAMgwaYMnQik7teQN4IAzC7npDv6kzeU6prfkR67bc87J1kWMPGkoaZSq1npmexMgkmEVg==",
+      "dev": true,
       "requires": {
         "mime-db": "1.42.0"
       }
@@ -10907,7 +10909,8 @@
     "oauth-sign": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
+      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
+      "dev": true
     },
     "object-assign": {
       "version": "4.1.1",
@@ -11411,7 +11414,8 @@
     "performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+      "dev": true
     },
     "pify": {
       "version": "4.0.1",
@@ -12701,7 +12705,8 @@
     "psl": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.4.0.tgz",
-      "integrity": "sha512-HZzqCGPecFLyoRj5HLfuDSKYTJkAfB5thKBIkRHtGjWwY7p1dAyveIbXIq4tO0KYfDF2tHqPUgY9SDnGm00uFw=="
+      "integrity": "sha512-HZzqCGPecFLyoRj5HLfuDSKYTJkAfB5thKBIkRHtGjWwY7p1dAyveIbXIq4tO0KYfDF2tHqPUgY9SDnGm00uFw==",
+      "dev": true
     },
     "public-encrypt": {
       "version": "4.0.3",
@@ -12753,7 +12758,8 @@
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "dev": true
     },
     "q": {
       "version": "1.5.1",
@@ -12764,7 +12770,8 @@
     "qs": {
       "version": "6.5.2",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
+      "dev": true
     },
     "querystring": {
       "version": "0.2.0",
@@ -13736,6 +13743,7 @@
       "version": "2.88.2",
       "resolved": "https://repo.sonatype.com/repository/npm-all/request/-/request-2.88.2.tgz",
       "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
+      "dev": true,
       "requires": {
         "aws-sign2": "~0.7.0",
         "aws4": "^1.8.0",
@@ -13763,6 +13771,7 @@
           "version": "2.5.0",
           "resolved": "https://repo.sonatype.com/repository/npm-all/tough-cookie/-/tough-cookie-2.5.0.tgz",
           "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+          "dev": true,
           "requires": {
             "psl": "^1.1.28",
             "punycode": "^2.1.1"
@@ -14213,7 +14222,8 @@
     "safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
     },
     "safe-regex": {
       "version": "1.1.0",
@@ -14227,7 +14237,8 @@
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true
     },
     "sane": {
       "version": "2.5.2",
@@ -15242,6 +15253,7 @@
       "version": "1.16.1",
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
       "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
+      "dev": true,
       "requires": {
         "asn1": "~0.2.3",
         "assert-plus": "^1.0.0",
@@ -15854,6 +15866,7 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+      "dev": true,
       "requires": {
         "safe-buffer": "^5.0.1"
       }
@@ -15861,7 +15874,8 @@
     "tweetnacl": {
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+      "dev": true
     },
     "type-check": {
       "version": "0.3.2",
@@ -16072,6 +16086,7 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
       "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+      "dev": true,
       "requires": {
         "punycode": "^2.1.0"
       }
@@ -16175,7 +16190,8 @@
     "uuid": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
-      "integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ=="
+      "integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ==",
+      "dev": true
     },
     "validate-npm-package-license": {
       "version": "3.0.4",
@@ -16202,6 +16218,7 @@
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+      "dev": true,
       "requires": {
         "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -182,20 +182,23 @@
     "generate-format": "./generate-format.sh"
   },
   "dependencies": {
+    "@types/node-fetch": "^2.5.7",
     "@types/platform": "^1.3.2",
+    "@types/request": "^2.48.5",
     "ansi-colors": "^4.1.1",
     "bootstrap": "^4.3.1",
     "gemfile": "^1.1.0",
     "http-status-codes": "^1.3.2",
     "jquery": "^3.4.0",
     "list-installed": "^1.0.0",
+    "node-fetch": "^2.6.1",
     "packageurl-js": "0.0.2",
     "react": "^16.11.0",
     "react-bootstrap": "^1.0.0-beta.14",
     "react-dom": "^16.11.0",
     "react-icons": "^3.7.0",
     "react-loader-spinner": "^3.1.2",
-    "request": "^2.88.0",
+    "request": "^2.88.2",
     "toml": "^3.0.0"
   },
   "devDependencies": {
@@ -205,7 +208,6 @@
     "@types/node": "^12.12.6",
     "@types/react": "^16.9.11",
     "@types/react-dom": "^16.9.3",
-    "@types/request": "^2.48.2",
     "@types/vscode": "1.23.0",
     "mustache": "^3.1.0",
     "react-scripts": "^2.1.3",

--- a/package.json
+++ b/package.json
@@ -182,9 +182,7 @@
     "generate-format": "./generate-format.sh"
   },
   "dependencies": {
-    "@types/node-fetch": "^2.5.7",
     "@types/platform": "^1.3.2",
-    "@types/request": "^2.48.5",
     "ansi-colors": "^4.1.1",
     "bootstrap": "^4.3.1",
     "gemfile": "^1.1.0",
@@ -198,10 +196,10 @@
     "react-dom": "^16.11.0",
     "react-icons": "^3.7.0",
     "react-loader-spinner": "^3.1.2",
-    "request": "^2.88.2",
     "toml": "^3.0.0"
   },
   "devDependencies": {
+    "@types/node-fetch": "^2.5.7",
     "@types/bootstrap": "^4.3.1",
     "@types/jest": "^22.2.3",
     "@types/lodash": "^4.14.136",


### PR DESCRIPTION
This is basically the start of removing request (very deprecated), in favor of `node-fetch`, the lightest of the libraries that exists.

Works completely for me, dropped `request` and it's types from the package.json, still builds and works, just fine.

Also this starts passing the logger to each service so we can log a lot more!