### PR TITLE
Simplify PyPI

### DIFF
--- a/ext-src/packages/pypi/PyPiUtils.ts
+++ b/ext-src/packages/pypi/PyPiUtils.ts
@@ -14,59 +14,41 @@
  * limitations under the License.
  */
 
-import { exec } from "../../utils/exec";
 import { PackageDependenciesHelper } from "../PackageDependenciesHelper";
 import { PyPIPackage } from './PyPIPackage';
-import { type } from 'os';
+import { readFileSync } from "fs";
+import { join } from "path";
 
 export class PyPiUtils {
   public async getDependencyArray(): Promise<Array<PyPIPackage>> {
-    const WINDOWS = "Windows_NT"
     try {
-      let command: string = "cat requirements.txt"
-      if (type() === WINDOWS) {
-        command = "type requirements.txt"
-      }
-      let {stdout, stderr } = await exec(command, {
-        cwd: PackageDependenciesHelper.getWorkspaceRoot(),
-        env: {
-          PATH: process.env.PATH
-        }
-      });
+      const requirements = readFileSync(
+        join(
+          PackageDependenciesHelper.getWorkspaceRoot(), 
+          "requirements.txt"));
 
-      if (stdout != "" && stderr === "") {
-        return Promise.resolve(this.parsePyPIDependencyTree(stdout));
-      } else {
-        return Promise.reject(
-          new Error(
-            "Error occurred in generating dependency tree. Check that there is not an issue with your requirements.txt"
-          )
-        );
-      }
-    } catch (e) {
+      return Promise.resolve(
+        this.parsePyPIDependencyTree(
+          requirements.toString()));
+    } catch (ex) {
       return Promise.reject(
-        `cat requirements.txt failed, try running it manually to see what went wrong: ${e.error}`
-      );
+        `Error occurred in generating dependency tree. Check that there is not an issue with your requirements.txt, ex: ${ex}`
+        );
     }
   }
 
   private parsePyPIDependencyTree(dependencyTree: string): Array<PyPIPackage> {
-    const dependencies: string = dependencyTree;
-    console.debug(dependencies);
-    console.debug(
-      "------------------------------------------------------------------------------"
-    );
     let dependencyList: PyPIPackage[] = [];
-    //numpy==1.16.4
-    const dependencyLines = dependencies.split("\n");
-    dependencyLines.forEach((dep) => {  
-      console.debug(dep);
+    dependencyTree.split("\n").forEach((dep) => {  
       if (dep.trim()) {
-        //ignore comments
         if (dep.startsWith("#")) {
           console.debug("Found comment, skipping");
         } else {
           const dependencyParts: string[] = dep.trim().split("==");
+          if (!dependencyParts || dependencyParts.length != 2) {
+            // Short circuit, we couldn't split, move on to next one
+            return;
+          }
           const name: string = dependencyParts[0];
           const version: string = dependencyParts[1];
           const extension: string = "tar.gz";
@@ -83,7 +65,7 @@ export class PyPiUtils {
             console.warn(
               "Skipping dependency: " +
                 dep +
-                " due to missing data (name, version, and/or extension)"
+                " due to missing data (name, version)"
             );
           }
         }


### PR DESCRIPTION
Basically, just use node utils to read requirements.txt, I have no idea why I used `cat` and `type` back when I did it, absolutely goofy when `readFileSync` exists.

This also adds a short circuit to the bit that parses out names and versions, if it can't split on `==` it will just move on to the next line.