### PR TITLE
Simplify the LiteDependencies approach, make it more testable, etc...

### DIFF
--- a/ext-src/models/OssIndexComponentModel.ts
+++ b/ext-src/models/OssIndexComponentModel.ts
@@ -62,11 +62,11 @@ export class OssIndexComponentModel implements ComponentModel {
               try {
 
                 this.logger.log(LogLevel.DEBUG, `Packaging Dependencies for ${pm.constructor.name}`);
-                await pm.packageForService();
+                const packages = await pm.packageForService();
     
                 progress.report({message: "Reticulating splines...", increment: 30});
   
-                purls.push(...pm.dependencies.map((x) => {
+                purls.push(...packages.map((x) => {
                   let matches = regex.exec(x.toPurl());
                   if (matches && matches.length === 4) {
                     return `${matches[1]}:${matches![2]}@${matches![3].replace("v", "")}`;

--- a/ext-src/packages/LitePackageDependencies.ts
+++ b/ext-src/packages/LitePackageDependencies.ts
@@ -16,9 +16,8 @@
 import { PackageType } from "./PackageType";
 
 export interface LitePackageDependencies {
-  dependencies: Array<PackageType>;
   format: string;
   manifestName: string;
   checkIfValid(): boolean;
-  packageForService(): Promise<any>;
+  packageForService(): Promise<Array<PackageType>>;
 }

--- a/ext-src/packages/cargo/CargoLiteDependencies.ts
+++ b/ext-src/packages/cargo/CargoLiteDependencies.ts
@@ -19,7 +19,6 @@ import { PackageDependenciesHelper } from "../PackageDependenciesHelper";
 import { CargoUtils } from "./CargoUtils";
 
 export class CargoLiteDependencies implements LitePackageDependencies {
-  dependencies: Array<CargoPackage> = [];
   manifestName: string = "cargo.lock";
   format: string = "cargo";
   
@@ -27,15 +26,15 @@ export class CargoLiteDependencies implements LitePackageDependencies {
     return PackageDependenciesHelper.checkIfValid(this.manifestName, this.format);
   }
 
-  public async packageForService(): Promise<any> {
+  public async packageForService(): Promise<Array<CargoPackage>> {
     try {
-      let cargoUtils = new CargoUtils();
-      this.dependencies = await cargoUtils.getDependencyArray();
+      const cargoUtils = new CargoUtils();
+      const deps = await cargoUtils.getDependencyArray();
 
-      Promise.resolve();
+      return Promise.resolve(deps);
     }
-    catch (e) {
-      Promise.reject(e);
+    catch (ex) {
+      return Promise.reject(ex);
     }
   }
 }

--- a/ext-src/packages/composer/ComposerLiteDependencies.ts
+++ b/ext-src/packages/composer/ComposerLiteDependencies.ts
@@ -19,7 +19,6 @@ import { PackageDependenciesHelper } from "../PackageDependenciesHelper";
 import { ComposerUtils } from "./ComposerUtils";
 
 export class ComposerLiteDependencies implements LitePackageDependencies {
-  dependencies: Array<ComposerPackage> = [];
   manifestName: string = "composer.lock";
   format: string = "composer";
   
@@ -27,15 +26,15 @@ export class ComposerLiteDependencies implements LitePackageDependencies {
     return PackageDependenciesHelper.checkIfValid(this.manifestName, this.format);
   }
 
-  public async packageForService(): Promise<any> {
+  public async packageForService(): Promise<Array<ComposerPackage>> {
     try {
-      let composerUtils = new ComposerUtils();
-      this.dependencies = await composerUtils.getDependencyArray();
+      const composerUtils = new ComposerUtils();
+      const deps = await composerUtils.getDependencyArray();
 
-      Promise.resolve();
+      return Promise.resolve(deps);
     }
     catch (e) {
-      Promise.reject(e);
+      return Promise.reject(e);
     }
   }
 }

--- a/ext-src/packages/golang/GolangLiteDependencies.ts
+++ b/ext-src/packages/golang/GolangLiteDependencies.ts
@@ -20,7 +20,6 @@ import { GolangUtils } from "./GolangUtils";
 import { GolangScanType } from "./GolangScanType";
 
 export class GolangLiteDependencies implements LitePackageDependencies {
-  dependencies: Array<GolangPackage> = [];
   manifestName: string = "go.sum";
   format: string = "golang";
   private scanType: string = "";
@@ -30,15 +29,15 @@ export class GolangLiteDependencies implements LitePackageDependencies {
     return this.scanType === "" ? false : true;
   }
 
-  public async packageForService(): Promise<any> {
+  public async packageForService(): Promise<Array<GolangPackage>> {
     try {
-      let golangUtils = new GolangUtils();
-      this.dependencies = await golangUtils.getDependencyArray(this.scanType);
+      const golangUtils = new GolangUtils();
+      const deps = await golangUtils.getDependencyArray(this.scanType);
 
-      Promise.resolve();
+      return Promise.resolve(deps);
     }
-    catch (e) {
-      Promise.reject(e);
+    catch (ex) {
+      return Promise.reject(ex);
     }
   }
 }

--- a/ext-src/packages/maven/MavenLiteDependencies.ts
+++ b/ext-src/packages/maven/MavenLiteDependencies.ts
@@ -19,7 +19,6 @@ import { PackageDependenciesHelper } from "../PackageDependenciesHelper";
 import { MavenUtils } from "./MavenUtils";
 
 export class MavenLiteDependencies implements LitePackageDependencies {
-  dependencies: Array<MavenPackage> = [];
   manifestName: string = "pom.xml";
   format: string = "maven";
 
@@ -27,15 +26,15 @@ export class MavenLiteDependencies implements LitePackageDependencies {
     return PackageDependenciesHelper.checkIfValid(this.manifestName, this.format);
   }
 
-  public async packageForService(): Promise<any> {
+  public async packageForService(): Promise<Array<MavenPackage>> {
     try {
-      let mavenUtils = new MavenUtils();
-      this.dependencies = await mavenUtils.getDependencyArray();
+      const mavenUtils = new MavenUtils();
+      const deps = await mavenUtils.getDependencyArray();
 
-      Promise.resolve();
+      return Promise.resolve(deps);
     }
-    catch (e) {
-      Promise.reject(e);
+    catch (ex) {
+      return Promise.reject(ex);
     }
   }
 }

--- a/ext-src/packages/npm/NpmLiteDependencies.ts
+++ b/ext-src/packages/npm/NpmLiteDependencies.ts
@@ -20,28 +20,24 @@ import { NpmUtils } from "./NpmUtils";
 import { NpmScanType } from "./NpmScanType";
 
 export class NpmLiteDependencies implements LitePackageDependencies {
-  dependencies: Array<NpmPackage> = [];
   format: string = "npm";
   manifestName: string = "package.json";
   private scanType: string = "";
-
-  constructor() {
-  }
 
   public checkIfValid(): boolean {
     this.scanType = PackageDependenciesHelper.checkIfValidWithArray(NpmScanType, this.format);
     return this.scanType === "" ? false : true;
   }
 
-  public async packageForService(): Promise<any> {
+  public async packageForService(): Promise<Array<NpmPackage>> {
     try {
-      let npmUtils = new NpmUtils();
-      this.dependencies = await npmUtils.getDependencyArray(this.scanType);
+      const npmUtils = new NpmUtils();
+      const deps = await npmUtils.getDependencyArray(this.scanType);
 
-      Promise.resolve();
+      return Promise.resolve(deps);
     }
-    catch (e) {
-      throw new TypeError(`There are problems, please check this error: ${e}`);
+    catch (ex) {
+      return Promise.reject(ex);
     }
   }
 }

--- a/ext-src/packages/poetry/PoetryLiteDependencies.ts
+++ b/ext-src/packages/poetry/PoetryLiteDependencies.ts
@@ -19,7 +19,6 @@ import { PoetryUtils } from './PoetryUtils';
 import { PackageDependenciesHelper } from "../PackageDependenciesHelper";
 
 export class PoetryLiteDependencies implements LitePackageDependencies {
-  dependencies: Array<PyPIPackage> = [];
   format: string = "pypi";
   manifestName: string = "poetry.lock";
 
@@ -27,15 +26,15 @@ export class PoetryLiteDependencies implements LitePackageDependencies {
     return PackageDependenciesHelper.checkIfValid(this.manifestName, this.format);
   }
 
-  public async packageForService(): Promise<any> {
+  public async packageForService(): Promise<Array<PyPIPackage>> {
     try {
       const poetryUtils = new PoetryUtils();
-      this.dependencies = await poetryUtils.getDependencyArray();
+      const deps = await poetryUtils.getDependencyArray();
 
-      Promise.resolve();
+      return Promise.resolve(deps);
     }
-    catch (e) {
-      Promise.reject(e);
+    catch (ex) {
+      return Promise.reject(ex);
     }
   }
 }

--- a/ext-src/packages/pypi/PyPiLiteDependencies.ts
+++ b/ext-src/packages/pypi/PyPiLiteDependencies.ts
@@ -19,7 +19,6 @@ import { PyPiUtils } from './PyPiUtils';
 import { PackageDependenciesHelper } from "../PackageDependenciesHelper";
 
 export class PyPiLiteDependencies implements LitePackageDependencies {
-  dependencies: Array<PyPIPackage> = [];
   format: string = "pypi";
   manifestName: string = "requirements.txt";
 
@@ -27,15 +26,15 @@ export class PyPiLiteDependencies implements LitePackageDependencies {
     return PackageDependenciesHelper.checkIfValid(this.manifestName, this.format);
   }
 
-  public async packageForService(): Promise<any> {
+  public async packageForService(): Promise<Array<PyPIPackage>> {
     try {
-      let pypiUtils = new PyPiUtils();
-      this.dependencies = await pypiUtils.getDependencyArray();
+      const pypiUtils = new PyPiUtils();
+      const deps = await pypiUtils.getDependencyArray();
 
-      Promise.resolve();
+      return Promise.resolve(deps);
     }
-    catch (e) {
-      Promise.reject(e);
+    catch (ex) {
+      return Promise.reject(ex);
     }
   }
 }

--- a/ext-src/packages/r/RLiteDependencies.ts
+++ b/ext-src/packages/r/RLiteDependencies.ts
@@ -19,7 +19,6 @@ import { RUtils } from './RUtils';
 import { PackageDependenciesHelper } from "../PackageDependenciesHelper";
 
 export class RLiteDependencies implements LitePackageDependencies {
-  dependencies: Array<RPackage> = [];
   format: string = "r";
   manifestName: string = ".Rbuildignore";
 
@@ -27,15 +26,15 @@ export class RLiteDependencies implements LitePackageDependencies {
     return PackageDependenciesHelper.checkIfValid(this.manifestName, this.format);
   }
 
-  public async packageForService(): Promise<any> {
+  public async packageForService(): Promise<Array<RPackage>> {
     try {
-      let rUtils = new RUtils();
-      this.dependencies = await rUtils.getDependencyArray();
+      const rUtils = new RUtils();
+      const deps = await rUtils.getDependencyArray();
 
-      Promise.resolve();
+      return Promise.resolve(deps);
     }
-    catch (e) {
-      Promise.reject(e);
+    catch (ex) {
+      return Promise.reject(ex);
     }
   }
 }

--- a/ext-src/packages/rubygems/RubyGemsLiteDependencies.ts
+++ b/ext-src/packages/rubygems/RubyGemsLiteDependencies.ts
@@ -19,7 +19,6 @@ import { RubyGemsUtils } from './RubyGemsUtils';
 import { PackageDependenciesHelper } from "../PackageDependenciesHelper";
 
 export class RubyGemLiteDependencies implements LitePackageDependencies {
-  dependencies: Array<RubyGemsPackage> = [];
   format: string = "rubygems";
   manifestName: string = "Gemfile.lock";
 
@@ -27,15 +26,15 @@ export class RubyGemLiteDependencies implements LitePackageDependencies {
     return PackageDependenciesHelper.checkIfValid(this.manifestName, this.format);
   }
 
-  public async packageForService(): Promise<any> {
+  public async packageForService(): Promise<Array<RubyGemsPackage>> {
     try {
-      let rubyGemsUtils = new RubyGemsUtils();
-      this.dependencies = await rubyGemsUtils.getDependencyArray();
+      const rubyGemsUtils = new RubyGemsUtils();
+      const deps = await rubyGemsUtils.getDependencyArray();
 
-      Promise.resolve();
+      return Promise.resolve(deps);
     }
     catch (e) {
-      Promise.reject(e);
+      return Promise.reject(e);
     }
   }
 }


### PR DESCRIPTION
This is just so that it will be easier to test the LiteDependencies package munchers, by skipping a few steps and returning the dependencies rather then leave them hanging on the class.

This impacts OSS Index only, so a nice test of those formats would be good (I personally tested quite a few).