### PR TITLE
Simplify Dependencies

### DIFF
--- a/ext-src/models/IqComponentModel.ts
+++ b/ext-src/models/IqComponentModel.ts
@@ -126,29 +126,39 @@ export class IqComponentModel implements ComponentModel {
               this.logger.log(LogLevel.TRACE, `Received results from Third Party API IQ Scan`, resultData);
               
               let results: ReportResponse;
-              if (resultData && resultData.reportHtmlUrl) {
-                let parts = /[^/]*$/.exec(resultData!.reportHtmlUrl!);
 
-                if (parts) {
-                  results = await this.requestService.getReportResults(parts[0], this.applicationPublicId);
+              if (resultData) {
+                let id: string = "";
+                if (resultData.reportHtmlUrl) {
+                  let parts = /[^/]*$/.exec(resultData!.reportHtmlUrl!);
+                  
+                  if (parts) {
+                    id = parts[0];
+                  }
+                } else if (resultData.scanId) {
+                  id = resultData.scanId;
+                } else {
+                  throw new RangeError("No ID to work with");
+                }
+
+                results = await this.requestService.getReportResults(id, this.applicationPublicId);
   
-                  this.logger.log(LogLevel.TRACE, `Received results from Report API`, results);
+                this.logger.log(LogLevel.TRACE, `Received results from Report API`, results);
 
-                  progress.report({message: "Morphing results into something usable", increment: 90});
+                progress.report({message: "Morphing results into something usable", increment: 90});
 
-                  for (let resultEntry of results.components) {                   
-                    let componentEntry = this.coordsToComponent.get(
-                      ComponentEntryConversions.ConvertToComponentEntry(
-                        resultEntry.componentIdentifier.format, 
-                        resultEntry.componentIdentifier.coordinates
-                        )
-                    );
+                for (let resultEntry of results.components) {                   
+                  let componentEntry = this.coordsToComponent.get(
+                    ComponentEntryConversions.ConvertToComponentEntry(
+                      resultEntry.componentIdentifier.format, 
+                      resultEntry.componentIdentifier.coordinates
+                      )
+                  );
 
-                    if (componentEntry != undefined) {
-                      componentEntry!.policyViolations = resultEntry.violations;
-                      componentEntry!.hash = resultEntry.hash;
-                      componentEntry!.nexusIQData = { component: resultEntry };
-                    }
+                  if (componentEntry != undefined) {
+                    componentEntry!.policyViolations = resultEntry.violations;
+                    componentEntry!.hash = resultEntry.hash;
+                    componentEntry!.nexusIQData = { component: resultEntry };
                   }
                 }
               }

--- a/ext-src/packages/PackageDependencies.ts
+++ b/ext-src/packages/PackageDependencies.ts
@@ -21,7 +21,6 @@ export interface PackageDependencies {
   CoordinatesToComponents: Map<string, ComponentEntry>;
   RequestService: RequestService;
   CheckIfValid(): boolean;
-  ConvertToComponentEntry(resultEntry: Array<PackageType>): string;
-  toComponentEntries(data: any): Array<ComponentEntry>;
+  toComponentEntries(data: Array<PackageType>): Array<ComponentEntry>;
   packageForIq(): Promise<Array<PackageType>>;
 }

--- a/ext-src/packages/cargo/CargoDependencies.ts
+++ b/ext-src/packages/cargo/CargoDependencies.ts
@@ -41,13 +41,6 @@ export class CargoDependencies extends PackageDependenciesHelper implements Pack
     return PackageDependenciesHelper.checkIfValid("Cargo.lock", "cargo");
   }
 
-  public ConvertToComponentEntry(resultEntry: any): string {
-    let coordinates = new CargoCoordinate(resultEntry.component.componentIdentifier.coordinates.name,
-      resultEntry.component.componentIdentifier.coordinates.version);
-    
-    return coordinates.asCoordinates();
-  }
-
   public toComponentEntries(packages: Array<CargoPackage>): Array<ComponentEntry> {
     let components = new Array<ComponentEntry>();
     for (let pkg of packages) {

--- a/ext-src/packages/composer/ComposerDependencies.ts
+++ b/ext-src/packages/composer/ComposerDependencies.ts
@@ -41,14 +41,6 @@ export class ComposerDependencies extends PackageDependenciesHelper implements P
     return PackageDependenciesHelper.checkIfValid("composer.lock", "composer");
   }
 
-  public ConvertToComponentEntry(resultEntry: any): string {
-    let coordinates = new ComposerCoordinate(resultEntry.component.componentIdentifier.coordinates.name,
-      resultEntry.component.componentIdentifier.coordinates.namespace,
-      resultEntry.component.componentIdentifier.coordinates.version);
-    
-    return coordinates.asCoordinates();
-  }
-
   public toComponentEntries(packages: Array<ComposerPackage>): Array<ComponentEntry> {
     let components = new Array<ComponentEntry>();
     for (let pkg of packages) {

--- a/ext-src/packages/golang/GolangDependencies.ts
+++ b/ext-src/packages/golang/GolangDependencies.ts
@@ -41,13 +41,6 @@ export class GolangDependencies extends PackageDependenciesHelper implements Pac
     return this.scanType === "" ? false : true;
   }
 
-  public ConvertToComponentEntry(resultEntry: any): string {
-    let coordinates = new GolangCoordinate(resultEntry.component.componentIdentifier.coordinates.name, 
-      resultEntry.component.componentIdentifier.coordinates.version);
-
-    return coordinates.asCoordinates();
-  }
-
   public toComponentEntries(packages: Array<GolangPackage>): Array<ComponentEntry> {
     let components = new Array<ComponentEntry>();
     for (let pkg of packages) {

--- a/ext-src/packages/maven/MavenDependencies.ts
+++ b/ext-src/packages/maven/MavenDependencies.ts
@@ -38,15 +38,6 @@ export class MavenDependencies extends PackageDependenciesHelper implements Pack
     return PackageDependenciesHelper.checkIfValid("pom.xml", "maven");
   }
 
-  public ConvertToComponentEntry(resultEntry: any): string {
-    let coordinates = new MavenCoordinate(resultEntry.component.componentIdentifier.coordinates.artifactId, 
-      resultEntry.component.componentIdentifier.coordinates.groupId, 
-      resultEntry.component.componentIdentifier.coordinates.version, 
-      resultEntry.component.componentIdentifier.coordinates.extension);
-
-    return coordinates.asCoordinates();
-  }
-
   public toComponentEntries(packages: Array<MavenPackage>): Array<ComponentEntry> {
     let components = new Array<ComponentEntry>();
     for (let pkg of packages) {

--- a/ext-src/packages/npm/NpmDependencies.ts
+++ b/ext-src/packages/npm/NpmDependencies.ts
@@ -51,13 +51,6 @@ export class NpmDependencies implements PackageDependencies {
     return this.scanType === "" ? false : true;
   }
 
-  public ConvertToComponentEntry(resultEntry: any): string {
-    let coordinates = new NpmCoordinate(resultEntry.component.componentIdentifier.coordinates.packageId, 
-      resultEntry.component.componentIdentifier.coordinates.version);
-    
-    return coordinates.asCoordinates();
-  }
-
   public toComponentEntries(packages: Array<NpmPackage>): Array<ComponentEntry> {
     let components = new Array<ComponentEntry>();
     for (let pkg of packages) {

--- a/ext-src/packages/poetry/PoetryDependencies.ts
+++ b/ext-src/packages/poetry/PoetryDependencies.ts
@@ -44,14 +44,6 @@ export class PoetryDependencies extends PyPIDependencies implements PackageDepen
     return false;
   }
 
-  public ConvertToComponentEntry(resultEntry: any): string {
-    let coordinates = new PyPICoordinate(resultEntry.component.componentIdentifier.coordinates.name,
-      resultEntry.component.componentIdentifier.coordinates.version,
-      "tar.gz", "");
-    
-    return coordinates.asCoordinates();
-  }
-
   public toComponentEntries(packages: Array<PyPIPackage>): Array<ComponentEntry> {
     let components = new Array<ComponentEntry>();
     for (let pkg of packages) {

--- a/ext-src/packages/pypi/PyPIDependencies.ts
+++ b/ext-src/packages/pypi/PyPIDependencies.ts
@@ -42,14 +42,6 @@ export class PyPIDependencies extends PackageDependenciesHelper implements Packa
     return false;
   }
 
-  public ConvertToComponentEntry(resultEntry: any): string {
-    let coordinates = new PyPICoordinate(resultEntry.component.componentIdentifier.coordinates.name,
-      resultEntry.component.componentIdentifier.coordinates.version,
-      "tar.gz", "");
-    
-    return coordinates.asCoordinates();
-  }
-
   public toComponentEntries(packages: Array<PyPIPackage>): Array<ComponentEntry> {
     let components = new Array<ComponentEntry>();
     for (let pkg of packages) {

--- a/ext-src/packages/rubygems/RubyGemsDependencies.ts
+++ b/ext-src/packages/rubygems/RubyGemsDependencies.ts
@@ -48,13 +48,6 @@ export class RubyGemsDependencies implements PackageDependencies {
     return PackageDependenciesHelper.checkIfValid('Gemfile.lock', 'rubygems');
   }
 
-  public ConvertToComponentEntry(resultEntry: any): string {
-    let coordinates = new RubyGemsCoordinate(resultEntry.component.componentIdentifier.coordinates.name, 
-      resultEntry.component.componentIdentifier.coordinates.version);
-    
-    return coordinates.asCoordinates();
-  }
-
   public toComponentEntries(packages: Array<RubyGemsPackage>): Array<ComponentEntry> {
     let components = new Array<ComponentEntry>();
     for (let pkg of packages) {

--- a/ext-src/packages/templates/Dependencies.mustache
+++ b/ext-src/packages/templates/Dependencies.mustache
@@ -42,13 +42,6 @@ export class {{&format}}Dependencies extends PackageDependenciesHelper implement
     return PackageDependenciesHelper.checkIfValid("", "{{&lowerCaseFormat}}");
   }
 
-  public ConvertToComponentEntry(resultEntry: any): string {
-    let coordinates = new {{&format}}Coordinate(resultEntry.component.componentIdentifier.coordinates.name,
-      resultEntry.component.componentIdentifier.coordinates.version);
-    
-    return coordinates.asCoordinates();
-  }
-
   public toComponentEntries(packages: Array<{{&format}}Package>): Array<ComponentEntry> {
     let components = new Array<ComponentEntry>();
     for (let pkg of packages) {

--- a/ext-src/services/IqRequestService.ts
+++ b/ext-src/services/IqRequestService.ts
@@ -209,6 +209,8 @@ export class IqRequestService implements RequestService {
             resolve(body);
             return;
           }
+          let body = await res.text();
+          this.logger.log(LogLevel.ERROR, `Issue getting report result`, url, body);
           reject(res.status);
           return;
         }).catch((ex) => {
@@ -229,12 +231,8 @@ export class IqRequestService implements RequestService {
         headers: this.getHeaders(),
         agent: this.agent
       }).then(async (res) => {
-        if (!res.ok) {
-          reject(res.status, 'uhh');
-          return;
-        }
-        if (res.status == 404) {
-          reject(res.status, 'Polling');
+        if (res.status == 404 || res.status == 500) {
+          reject(404, 'Polling');
           return;
         }
         let json: ThirdPartyAPIResponse = await res.json();

--- a/ext-src/services/ThirdPartyApiResponse.ts
+++ b/ext-src/services/ThirdPartyApiResponse.ts
@@ -4,4 +4,5 @@ export interface ThirdPartyAPIResponse {
     reportHtmlUrl?: string;
     isError: boolean;
     errorMessage?: string;
+    scanId?: string;
 }

--- a/src/components/Loader/SonatypeLoader.tsx
+++ b/src/components/Loader/SonatypeLoader.tsx
@@ -15,7 +15,6 @@
  */
 import React, { Component } from "react";
 
-// image import
 import logo from "./SON_logo_favicon.png";
 
 class SonatypeLoader extends Component {


### PR DESCRIPTION
Quick lil ditty, tighten up some contracts and remove dead code.

Basically, `ConvertToComponentEntry(resultEntry: Array<PackageType>): string;` was moved into a Utils class (we do this portion of things after we exit the package munchers, so it made more sense there, for now), and deleted the implementations on the package munchers. As well made the contract on toComponentEntries tighter for the param it receives). 