### PR TITLE
Handle semicolons in auto-generated requirements.txt files

### DIFF
--- a/ext-src/packages/pypi/PyPiUtils.ts
+++ b/ext-src/packages/pypi/PyPiUtils.ts
@@ -44,6 +44,7 @@ export class PyPiUtils {
         if (dep.startsWith("#")) {
           console.debug("Found comment, skipping");
         } else {
+          // remove any conditionals after semicolon, split result to get package and version
           const dependencyParts: string[] = dep.split(";")[0].trim().split("==");
           if (!dependencyParts || dependencyParts.length != 2) {
             // Short circuit, we couldn't split, move on to next one

--- a/ext-src/packages/pypi/PyPiUtils.ts
+++ b/ext-src/packages/pypi/PyPiUtils.ts
@@ -44,7 +44,7 @@ export class PyPiUtils {
         if (dep.startsWith("#")) {
           console.debug("Found comment, skipping");
         } else {
-          const dependencyParts: string[] = dep.trim().split("==");
+          const dependencyParts: string[] = dep.split(";")[0].trim().split("==");
           if (!dependencyParts || dependencyParts.length != 2) {
             // Short circuit, we couldn't split, move on to next one
             return;


### PR DESCRIPTION
Handle the requirements.txt file containing semicolons in line.  Requirements.txt file auto generated by pipenv can contain these semicolons.

`python-dateutil==2.8.1; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'`

This pull request makes the following changes:
* Adds a split to the dep line


cc @bhamail / @DarthHater 
