### PR TITLE
Better error from a bad application ID response

### DIFF
--- a/ext-src/models/IqComponentModel.ts
+++ b/ext-src/models/IqComponentModel.ts
@@ -96,12 +96,10 @@ export class IqComponentModel implements ComponentModel {
               this.logger.log(LogLevel.DEBUG, `Getting Internal ID from Public ID: ${this.applicationPublicId}`);
               progress.report({message: "Getting IQ Server Internal Application ID", increment: 40});
               
-              let response: string = await this.requestService.getApplicationId(this.applicationPublicId);
-              this.logger.log(LogLevel.TRACE, `Obtained internal application ID response`, response);
-              
-              let appRep = JSON.parse(response);
+              let internalID: string = await this.requestService.getApplicationId(this.applicationPublicId);
+              this.logger.log(LogLevel.TRACE, `Obtained internal application ID response`, internalID);
         
-              this.requestService.setApplicationId(appRep.applications[0].id);
+              this.requestService.setApplicationId(internalID);
               this.logger.log(
                 LogLevel.DEBUG, 
                 `Set application internal ID: ${this.requestService.getApplicationInternalId()}`

--- a/ext-src/services/ApplicationReponse.ts
+++ b/ext-src/services/ApplicationReponse.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2019-present Sonatype, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+export interface ApplicationTag {
+    id: string;
+    tagId: string;
+    applicationId: string;
+}
+
+export interface Application {
+    id: string;
+    publicId: string;
+    name: string;
+    organizationId: string;
+    contactUserName: string;
+    applicationTags: ApplicationTag[];
+}
+
+export interface ApplicationResponse {
+    applications: Application[];
+}

--- a/ext-src/services/IqRequestService.ts
+++ b/ext-src/services/IqRequestService.ts
@@ -70,6 +70,10 @@ export class IqRequestService implements RequestService {
   }
 
   public getApplicationId(applicationPublicId: string): Promise<string> {
+    if (applicationPublicId === '') {
+      throw Error(`You must provide a non empty public application ID in your Sonatype IQ Server Config`);
+    }
+
     this.logger.log(LogLevel.TRACE, `Getting application ID from public ID: ${applicationPublicId}`);
 
     let url = `${this.url}/api/v2/applications?publicId=${applicationPublicId}`;
@@ -82,9 +86,7 @@ export class IqRequestService implements RequestService {
           agent: this.agent
         }).then(async (res) => {
           if (res.ok) {
-            let json = await res.json();
-
-            let appRep: ApplicationResponse = JSON.parse(json);
+            let appRep: ApplicationResponse = await res.json();
 
             if (appRep && appRep.applications.length > 0) {
               resolve(appRep.applications[0].id);
@@ -94,14 +96,13 @@ export class IqRequestService implements RequestService {
                 LogLevel.ERROR,
                 `No valid application found using the public ID: ${applicationPublicId}`, 
                 url,
-                json,
                 appRep
               );
               reject(`No valid application found using the public ID: ${applicationPublicId}`);
               return;
             }
           }
-          
+
           let body = await res.text();
           this.logger.log(
             LogLevel.TRACE, 

--- a/ext-src/services/IqRequestService.ts
+++ b/ext-src/services/IqRequestService.ts
@@ -26,6 +26,7 @@ import { ReportResponse } from './ReportResponse';
 import { PackageURL } from 'packageurl-js';
 import { VulnerabilityResponse } from './VulnerabilityResponse';
 import { RemediationResponse } from './RemediationResponse';
+import { ApplicationResponse } from './ApplicationReponse';
 
 export class IqRequestService implements RequestService {
   readonly evaluationPollDelayMs = 2000;
@@ -82,9 +83,25 @@ export class IqRequestService implements RequestService {
         }).then(async (res) => {
           if (res.ok) {
             let json = await res.json();
-            resolve(JSON.stringify(json));
-            return;
+
+            let appRep: ApplicationResponse = JSON.parse(json);
+
+            if (appRep && appRep.applications.length > 0) {
+              resolve(appRep.applications[0].id);
+              return;
+            } else {
+              this.logger.log(
+                LogLevel.ERROR,
+                `No valid application found using the public ID: ${applicationPublicId}`, 
+                url,
+                json,
+                appRep
+              );
+              reject(`No valid application found using the public ID: ${applicationPublicId}`);
+              return;
+            }
           }
+          
           let body = await res.text();
           this.logger.log(
             LogLevel.TRACE, 

--- a/package.json
+++ b/package.json
@@ -186,7 +186,7 @@
     ]
   },
   "scripts": {
-    "build": "webpack",
+    "build": "webpack --mode development",
     "generate-format": "./generate-format.sh",
     "vscode:prepublish": "webpack --mode production",
     "webpack": "webpack --mode development",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -41,6 +41,9 @@ const extensionConfig = {
                 }
             }]
         }]
+    },
+    optimization: {
+        minimize: false
     }
 }
 


### PR DESCRIPTION
Based on #173 , I wanted to see if it was easy to improve the error logged, as well as just handle everything better.

This pull request makes the following changes:
* Strongly types the app response, so we can do some better stuff with time (what if you find two apps, which one is it?!?!, etc....)
* Moves the logic to parse out the application ID inside the service (it's more appropriate here, consumer shouldn't really care how to parse the json in this case)
* ????
* PROFIT!!!!

It relates to the following issue #s:
* Fixes #173 #87 

cc @bhamail / @DarthHater 
