### PR TITLE
Refresh IQ stuff when App ID is changed

### DIFF
--- a/ext-src/NexusExplorer.ts
+++ b/ext-src/NexusExplorer.ts
@@ -247,18 +247,19 @@ export class NexusExplorer {
     }
   }
 
-  // public updateIQUrl(url: string) {
-  //   if (this.componentModel instanceof IqComponentModel) {
-  //     this.componentModel.url = url;
+  public updateIQUrl(url: string) {
+    if (this.componentModel instanceof IqComponentModel) {
+      this.componentModel.url = url;
+      this.componentModel.requestService.setUrl(url);
 
-  //     this.nexusExplorerProvider.doRefresh();
-  //   }
-  // }
+      this.nexusExplorerProvider.doRefresh();
+    }
+  }
 
   public updateIQUser(user: string) {
     if (this.componentModel instanceof IqComponentModel) {
       this.componentModel.username = user;
-      this.componentModel.requestService.setUser(user)
+      this.componentModel.requestService.setUser(user);
 
       this.nexusExplorerProvider.doRefresh();
     }

--- a/ext-src/NexusExplorer.ts
+++ b/ext-src/NexusExplorer.ts
@@ -247,49 +247,19 @@ export class NexusExplorer {
     }
   }
 
-  // public updateIQUrl(url: string) {
-  //   if (this.componentModel instanceof IqComponentModel) {
-  //     this.componentModel.url = url;
-  //     this.componentModel.requestService.setUrl(url);
-
-  //     this.nexusExplorerProvider.doRefresh();
-  //   }
-  // }
-
-  // public updateIQUser(user: string) {
-  //   if (this.componentModel instanceof IqComponentModel) {
-  //     this.componentModel.username = user;
-  //     this.componentModel.requestService.setUser(user);
-
-  //     this.nexusExplorerProvider.doRefresh();
-  //   }
-  // }
-
-  // public updateIQPassword(password: string) {
-  //   if (this.componentModel instanceof IqComponentModel) {
-  //     this.componentModel.password = password;
-  //     this.componentModel.requestService.setPassword(password);
-
-  //     this.nexusExplorerProvider.doRefresh();
-  //   }
-  // }
-
-  public refreshIQRequestService(url?: string, user?: string, password?: string) {
+  public refreshIQRequestService(options: RefreshOptions) {
     if (this.componentModel instanceof IqComponentModel) {
-      if (url) {
-        this.componentModel.url = url;
-        this.componentModel.requestService.setUrl(url);
-      }
-      if (user) {
-        this.componentModel.username = user;
-        this.componentModel.requestService.setUser(user);
-      }
-      if (password) {
-        this.componentModel.password = password;
-        this.componentModel.requestService.setPassword(password);
-      }
+      if (options) {
+        this.componentModel.requestService.setOptions(options);
 
-      this.nexusExplorerProvider.doRefresh();
+        this.nexusExplorerProvider.doRefresh();
+      }
     }
   }
+}
+
+export interface RefreshOptions {
+  url: string,
+  username: string,
+  token: string
 }

--- a/ext-src/NexusExplorer.ts
+++ b/ext-src/NexusExplorer.ts
@@ -237,4 +237,12 @@ export class NexusExplorer {
 
     this.nexusExplorerProvider.doRefresh();
   }
+
+  public updateApplicationID(applicationID: string) {
+    if (this.componentModel instanceof IqComponentModel) {
+      this.componentModel.applicationPublicId = applicationID;
+
+      this.nexusExplorerProvider.doRefresh();
+    }
+  }
 }

--- a/ext-src/NexusExplorer.ts
+++ b/ext-src/NexusExplorer.ts
@@ -238,9 +238,33 @@ export class NexusExplorer {
     this.nexusExplorerProvider.doRefresh();
   }
 
-  public updateApplicationID(applicationID: string) {
+  public updateIQAppID(applicationID: string) {
     if (this.componentModel instanceof IqComponentModel) {
       this.componentModel.applicationPublicId = applicationID;
+
+      this.nexusExplorerProvider.doRefresh();
+    }
+  }
+
+  public updateIQUrl(url: string) {
+    if (this.componentModel instanceof IqComponentModel) {
+      this.componentModel.url = url;
+
+      this.nexusExplorerProvider.doRefresh();
+    }
+  }
+
+  public updateIQUser(user: string) {
+    if (this.componentModel instanceof IqComponentModel) {
+      this.componentModel.username = user;
+
+      this.nexusExplorerProvider.doRefresh();
+    }
+  }
+
+  public updateIQPassword(password: string) {
+    if (this.componentModel instanceof IqComponentModel) {
+      this.componentModel.password = password;
 
       this.nexusExplorerProvider.doRefresh();
     }

--- a/ext-src/NexusExplorer.ts
+++ b/ext-src/NexusExplorer.ts
@@ -22,6 +22,7 @@ import { OssIndexComponentModel } from "./models/OssIndexComponentModel";
 import { ComponentModel } from "./models/ComponentModel";
 import { ComponentEntry } from "./models/ComponentEntry";
 import { ILogger, Logger, LogLevel } from './utils/Logger';
+import {NEXUS_IQ_SERVER_URL} from "./utils/Config";
 
 export class NexusExplorerProvider implements vscode.TreeDataProvider<ComponentEntry> {
   private editor?: vscode.TextEditor;
@@ -246,17 +247,18 @@ export class NexusExplorer {
     }
   }
 
-  public updateIQUrl(url: string) {
-    if (this.componentModel instanceof IqComponentModel) {
-      this.componentModel.url = url;
+  // public updateIQUrl(url: string) {
+  //   if (this.componentModel instanceof IqComponentModel) {
+  //     this.componentModel.url = url;
 
-      this.nexusExplorerProvider.doRefresh();
-    }
-  }
+  //     this.nexusExplorerProvider.doRefresh();
+  //   }
+  // }
 
   public updateIQUser(user: string) {
     if (this.componentModel instanceof IqComponentModel) {
       this.componentModel.username = user;
+      this.componentModel.requestService.setUser(user)
 
       this.nexusExplorerProvider.doRefresh();
     }
@@ -265,6 +267,7 @@ export class NexusExplorer {
   public updateIQPassword(password: string) {
     if (this.componentModel instanceof IqComponentModel) {
       this.componentModel.password = password;
+      this.componentModel.requestService.setPassword(password)
 
       this.nexusExplorerProvider.doRefresh();
     }

--- a/ext-src/NexusExplorer.ts
+++ b/ext-src/NexusExplorer.ts
@@ -247,28 +247,47 @@ export class NexusExplorer {
     }
   }
 
-  public updateIQUrl(url: string) {
+  // public updateIQUrl(url: string) {
+  //   if (this.componentModel instanceof IqComponentModel) {
+  //     this.componentModel.url = url;
+  //     this.componentModel.requestService.setUrl(url);
+
+  //     this.nexusExplorerProvider.doRefresh();
+  //   }
+  // }
+
+  // public updateIQUser(user: string) {
+  //   if (this.componentModel instanceof IqComponentModel) {
+  //     this.componentModel.username = user;
+  //     this.componentModel.requestService.setUser(user);
+
+  //     this.nexusExplorerProvider.doRefresh();
+  //   }
+  // }
+
+  // public updateIQPassword(password: string) {
+  //   if (this.componentModel instanceof IqComponentModel) {
+  //     this.componentModel.password = password;
+  //     this.componentModel.requestService.setPassword(password);
+
+  //     this.nexusExplorerProvider.doRefresh();
+  //   }
+  // }
+
+  public refreshIQRequestService(url?: string, user?: string, password?: string) {
     if (this.componentModel instanceof IqComponentModel) {
-      this.componentModel.url = url;
-      this.componentModel.requestService.setUrl(url);
-
-      this.nexusExplorerProvider.doRefresh();
-    }
-  }
-
-  public updateIQUser(user: string) {
-    if (this.componentModel instanceof IqComponentModel) {
-      this.componentModel.username = user;
-      this.componentModel.requestService.setUser(user);
-
-      this.nexusExplorerProvider.doRefresh();
-    }
-  }
-
-  public updateIQPassword(password: string) {
-    if (this.componentModel instanceof IqComponentModel) {
-      this.componentModel.password = password;
-      this.componentModel.requestService.setPassword(password)
+      if (url) {
+        this.componentModel.url = url;
+        this.componentModel.requestService.setUrl(url);
+      }
+      if (user) {
+        this.componentModel.username = user;
+        this.componentModel.requestService.setUser(user);
+      }
+      if (password) {
+        this.componentModel.password = password;
+        this.componentModel.requestService.setPassword(password);
+      }
 
       this.nexusExplorerProvider.doRefresh();
     }

--- a/ext-src/extension.ts
+++ b/ext-src/extension.ts
@@ -15,7 +15,7 @@
  */
 import * as vscode from 'vscode';
 import { NexusExplorer } from './NexusExplorer';
-import { NEXUS_EXPLORER_DATA_SOURCE, NEXUS_IQ_PUBLIC_APPLICATION_ID } from './utils/Config';
+import { NEXUS_EXPLORER_DATA_SOURCE, NEXUS_IQ_PUBLIC_APPLICATION_ID, NEXUS_IQ_SERVER_URL, NEXUS_IQ_USERNAME, NEXUS_IQ_USER_PASSWORD } from './utils/Config';
 
 export function activate(context: vscode.ExtensionContext) {
 
@@ -28,7 +28,19 @@ export function activate(context: vscode.ExtensionContext) {
 		}
 
 		if (event.affectsConfiguration(NEXUS_IQ_PUBLIC_APPLICATION_ID)) {
-			explorer.updateApplicationID(vscode.workspace.getConfiguration().get(NEXUS_IQ_PUBLIC_APPLICATION_ID) + "");
+			explorer.updateIQAppID(vscode.workspace.getConfiguration().get(NEXUS_IQ_PUBLIC_APPLICATION_ID) + "");
+		}
+
+		if (event.affectsConfiguration(NEXUS_IQ_SERVER_URL)) {
+			explorer.updateIQUrl(vscode.workspace.getConfiguration().get(NEXUS_IQ_SERVER_URL) + "");
+		}
+
+		if (event.affectsConfiguration(NEXUS_IQ_USERNAME)) {
+			explorer.updateIQUser(vscode.workspace.getConfiguration().get(NEXUS_IQ_USERNAME) + "");
+		}
+
+		if (event.affectsConfiguration(NEXUS_IQ_USER_PASSWORD)) {
+			explorer.updateIQPassword(vscode.workspace.getConfiguration().get(NEXUS_IQ_USER_PASSWORD) + "");
 		}
 	});
 

--- a/ext-src/extension.ts
+++ b/ext-src/extension.ts
@@ -25,34 +25,22 @@ export function activate(context: vscode.ExtensionContext) {
 	// Listen to changes of the configuration, and updates things if we need to
 	const eventConfigDisposable = vscode.workspace.onDidChangeConfiguration((event) => {
 		if (event.affectsConfiguration(NEXUS_EXPLORER_DATA_SOURCE)) {
-			explorer.switchComponentModel(vscode.workspace.getConfiguration().get(NEXUS_EXPLORER_DATA_SOURCE) + "");
+			explorer.switchComponentModel(vscode.workspace.getConfiguration().get(NEXUS_EXPLORER_DATA_SOURCE) as string);
 		}
 
 		if (event.affectsConfiguration(NEXUS_IQ_PUBLIC_APPLICATION_ID)) {
-			explorer.updateIQAppID(vscode.workspace.getConfiguration().get(NEXUS_IQ_PUBLIC_APPLICATION_ID) + "");
+			explorer.updateIQAppID(vscode.workspace.getConfiguration().get(NEXUS_IQ_PUBLIC_APPLICATION_ID) as string);
 		}
 
 		if (event.affectsConfiguration(NEXUS_IQ_SERVER_URL) ||
 			event.affectsConfiguration(NEXUS_IQ_USERNAME) || 
 			event.affectsConfiguration(NEXUS_IQ_USER_PASSWORD)) {
 			explorer.refreshIQRequestService(
-				vscode.workspace.getConfiguration().get(NEXUS_IQ_SERVER_URL) + "",
-				vscode.workspace.getConfiguration().get(NEXUS_IQ_USERNAME) + "",
-				vscode.workspace.getConfiguration().get(NEXUS_IQ_USER_PASSWORD) + ""
+				{ url: vscode.workspace.getConfiguration().get(NEXUS_IQ_SERVER_URL) as string,
+				 username: vscode.workspace.getConfiguration().get(NEXUS_IQ_USERNAME) as string,
+				 token: vscode.workspace.getConfiguration().get(NEXUS_IQ_USER_PASSWORD) as string}
 			)
 		}
-
-		// if (event.affectsConfiguration(NEXUS_IQ_SERVER_URL)) {
-		// 	explorer.updateIQUrl(vscode.workspace.getConfiguration().get(NEXUS_IQ_SERVER_URL) + "");
-		// }
-
-		// if (event.affectsConfiguration(NEXUS_IQ_USERNAME)) {
-		// 	explorer.updateIQUser(vscode.workspace.getConfiguration().get(NEXUS_IQ_USERNAME) + "");
-		// }
-
-		// if (event.affectsConfiguration(NEXUS_IQ_USER_PASSWORD)) {
-		// 	explorer.updateIQPassword(vscode.workspace.getConfiguration().get(NEXUS_IQ_USER_PASSWORD) + "");
-		// }
 	});
 
 	context.subscriptions.push(eventConfigDisposable);

--- a/ext-src/extension.ts
+++ b/ext-src/extension.ts
@@ -15,18 +15,22 @@
  */
 import * as vscode from 'vscode';
 import { NexusExplorer } from './NexusExplorer';
+import { NEXUS_EXPLORER_DATA_SOURCE, NEXUS_IQ_PUBLIC_APPLICATION_ID } from './utils/Config';
 
 export function activate(context: vscode.ExtensionContext) {
 
 	const explorer = new NexusExplorer(context);
 
 	// Listen to changes of the configuration, and if it's a change to the datasource, reload the dang thing
-	vscode.workspace.onDidChangeConfiguration((event) => {
-		let affected = event.affectsConfiguration("nexusExplorer.dataSource");
+	const eventConfigDisposable = vscode.workspace.onDidChangeConfiguration((event) => {
+		if (event.affectsConfiguration(NEXUS_EXPLORER_DATA_SOURCE)) {
+			explorer.switchComponentModel(vscode.workspace.getConfiguration().get(NEXUS_EXPLORER_DATA_SOURCE) + "");
+		}
 
-		if (affected) {
-			let source = vscode.workspace.getConfiguration().get("nexusExplorer.dataSource") + "";
-			explorer.switchComponentModel(source);
+		if (event.affectsConfiguration(NEXUS_IQ_PUBLIC_APPLICATION_ID)) {
+			explorer.updateApplicationID(vscode.workspace.getConfiguration().get(NEXUS_IQ_PUBLIC_APPLICATION_ID) + "");
 		}
 	});
+
+	context.subscriptions.push(eventConfigDisposable);
 }

--- a/ext-src/extension.ts
+++ b/ext-src/extension.ts
@@ -31,9 +31,9 @@ export function activate(context: vscode.ExtensionContext) {
 			explorer.updateIQAppID(vscode.workspace.getConfiguration().get(NEXUS_IQ_PUBLIC_APPLICATION_ID) + "");
 		}
 
-		// if (event.affectsConfiguration(NEXUS_IQ_SERVER_URL)) {
-		// 	explorer.updateIQUrl(vscode.workspace.getConfiguration().get(NEXUS_IQ_SERVER_URL) + "");
-		// }
+		if (event.affectsConfiguration(NEXUS_IQ_SERVER_URL)) {
+			explorer.updateIQUrl(vscode.workspace.getConfiguration().get(NEXUS_IQ_SERVER_URL) + "");
+		}
 
 		if (event.affectsConfiguration(NEXUS_IQ_USERNAME)) {
 			explorer.updateIQUser(vscode.workspace.getConfiguration().get(NEXUS_IQ_USERNAME) + "");

--- a/ext-src/extension.ts
+++ b/ext-src/extension.ts
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import {url} from 'inspector';
 import * as vscode from 'vscode';
 import { NexusExplorer } from './NexusExplorer';
 import { NEXUS_EXPLORER_DATA_SOURCE, NEXUS_IQ_PUBLIC_APPLICATION_ID, NEXUS_IQ_SERVER_URL, NEXUS_IQ_USERNAME, NEXUS_IQ_USER_PASSWORD } from './utils/Config';
@@ -31,17 +32,27 @@ export function activate(context: vscode.ExtensionContext) {
 			explorer.updateIQAppID(vscode.workspace.getConfiguration().get(NEXUS_IQ_PUBLIC_APPLICATION_ID) + "");
 		}
 
-		if (event.affectsConfiguration(NEXUS_IQ_SERVER_URL)) {
-			explorer.updateIQUrl(vscode.workspace.getConfiguration().get(NEXUS_IQ_SERVER_URL) + "");
+		if (event.affectsConfiguration(NEXUS_IQ_SERVER_URL) ||
+			event.affectsConfiguration(NEXUS_IQ_USERNAME) || 
+			event.affectsConfiguration(NEXUS_IQ_USER_PASSWORD)) {
+			explorer.refreshIQRequestService(
+				vscode.workspace.getConfiguration().get(NEXUS_IQ_SERVER_URL) + "",
+				vscode.workspace.getConfiguration().get(NEXUS_IQ_USERNAME) + "",
+				vscode.workspace.getConfiguration().get(NEXUS_IQ_USER_PASSWORD) + ""
+			)
 		}
 
-		if (event.affectsConfiguration(NEXUS_IQ_USERNAME)) {
-			explorer.updateIQUser(vscode.workspace.getConfiguration().get(NEXUS_IQ_USERNAME) + "");
-		}
+		// if (event.affectsConfiguration(NEXUS_IQ_SERVER_URL)) {
+		// 	explorer.updateIQUrl(vscode.workspace.getConfiguration().get(NEXUS_IQ_SERVER_URL) + "");
+		// }
 
-		if (event.affectsConfiguration(NEXUS_IQ_USER_PASSWORD)) {
-			explorer.updateIQPassword(vscode.workspace.getConfiguration().get(NEXUS_IQ_USER_PASSWORD) + "");
-		}
+		// if (event.affectsConfiguration(NEXUS_IQ_USERNAME)) {
+		// 	explorer.updateIQUser(vscode.workspace.getConfiguration().get(NEXUS_IQ_USERNAME) + "");
+		// }
+
+		// if (event.affectsConfiguration(NEXUS_IQ_USER_PASSWORD)) {
+		// 	explorer.updateIQPassword(vscode.workspace.getConfiguration().get(NEXUS_IQ_USER_PASSWORD) + "");
+		// }
 	});
 
 	context.subscriptions.push(eventConfigDisposable);

--- a/ext-src/extension.ts
+++ b/ext-src/extension.ts
@@ -21,7 +21,7 @@ export function activate(context: vscode.ExtensionContext) {
 
 	const explorer = new NexusExplorer(context);
 
-	// Listen to changes of the configuration, and if it's a change to the datasource, reload the dang thing
+	// Listen to changes of the configuration, and updates things if we need to
 	const eventConfigDisposable = vscode.workspace.onDidChangeConfiguration((event) => {
 		if (event.affectsConfiguration(NEXUS_EXPLORER_DATA_SOURCE)) {
 			explorer.switchComponentModel(vscode.workspace.getConfiguration().get(NEXUS_EXPLORER_DATA_SOURCE) + "");

--- a/ext-src/extension.ts
+++ b/ext-src/extension.ts
@@ -31,9 +31,9 @@ export function activate(context: vscode.ExtensionContext) {
 			explorer.updateIQAppID(vscode.workspace.getConfiguration().get(NEXUS_IQ_PUBLIC_APPLICATION_ID) + "");
 		}
 
-		if (event.affectsConfiguration(NEXUS_IQ_SERVER_URL)) {
-			explorer.updateIQUrl(vscode.workspace.getConfiguration().get(NEXUS_IQ_SERVER_URL) + "");
-		}
+		// if (event.affectsConfiguration(NEXUS_IQ_SERVER_URL)) {
+		// 	explorer.updateIQUrl(vscode.workspace.getConfiguration().get(NEXUS_IQ_SERVER_URL) + "");
+		// }
 
 		if (event.affectsConfiguration(NEXUS_IQ_USERNAME)) {
 			explorer.updateIQUser(vscode.workspace.getConfiguration().get(NEXUS_IQ_USERNAME) + "");

--- a/ext-src/models/IqComponentModel.ts
+++ b/ext-src/models/IqComponentModel.ts
@@ -25,6 +25,14 @@ import { ILogger, LogLevel } from "../utils/Logger";
 import { PackageType } from "../packages/PackageType";
 import { CycloneDXSbomCreator } from "../cyclonedx/CycloneDXGenerator";
 import { ReportResponse } from "../services/ReportResponse";
+import { 
+  NEXUS_EXPLORER_DATA_SOURCE, 
+  NEXUS_IQ_MAX_EVAL_POLL_ATTEMPTS, 
+  NEXUS_IQ_PUBLIC_APPLICATION_ID, 
+  NEXUS_IQ_SERVER_URL, 
+  NEXUS_IQ_STRICT_SSL, 
+  NEXUS_IQ_USERNAME, 
+  NEXUS_IQ_USER_PASSWORD } from "../utils/Config";
 
 export class IqComponentModel implements ComponentModel {
     components = new Array<ComponentEntry>();
@@ -40,14 +48,14 @@ export class IqComponentModel implements ComponentModel {
     constructor(
       options: ComponentModelOptions
     ) {
-      this.dataSourceType = options.configuration.get("nexusExplorer.dataSource", "ossindex");
-      let url = options.configuration.get("nexusIQ.serverUrl") + "";
-      let username = options.configuration.get("nexusIQ.username") + "";
+      this.dataSourceType = options.configuration.get(NEXUS_EXPLORER_DATA_SOURCE, "ossindex");
+      let url = options.configuration.get(NEXUS_IQ_SERVER_URL) + "";
+      let username = options.configuration.get(NEXUS_IQ_USERNAME) + "";
       let maximumEvaluationPollAttempts = parseInt(
-        options.configuration.get("nexusIQ.maximumEvaluationPollAttempts") + "", 10);
-      this.applicationPublicId = options.configuration.get("nexusIQ.applicationId") + "";
-      let password = options.configuration.get("nexusIQ.userPassword") + "";
-      let strictSSL = options.configuration.get("nexusIQ.strictSSL") as boolean;
+        options.configuration.get(NEXUS_IQ_MAX_EVAL_POLL_ATTEMPTS) + "", 10);
+      this.applicationPublicId = options.configuration.get(NEXUS_IQ_PUBLIC_APPLICATION_ID) + "";
+      let password = options.configuration.get(NEXUS_IQ_USER_PASSWORD) + "";
+      let strictSSL = options.configuration.get(NEXUS_IQ_STRICT_SSL) as boolean;
       this.requestService = new IqRequestService(url, username, password, maximumEvaluationPollAttempts, strictSSL, options.logger);
       this.logger = options.logger;
     }

--- a/ext-src/models/IqComponentModel.ts
+++ b/ext-src/models/IqComponentModel.ts
@@ -43,20 +43,23 @@ export class IqComponentModel implements ComponentModel {
     requestService: RequestService;
     dataSourceType: string;
     applicationPublicId: string;
+    url: string;
+    username: string;
+    password: string;
     private logger: ILogger;
   
     constructor(
       options: ComponentModelOptions
     ) {
       this.dataSourceType = options.configuration.get(NEXUS_EXPLORER_DATA_SOURCE, "ossindex");
-      let url = options.configuration.get(NEXUS_IQ_SERVER_URL) + "";
-      let username = options.configuration.get(NEXUS_IQ_USERNAME) + "";
+      this.url = options.configuration.get(NEXUS_IQ_SERVER_URL) + "";
+      this.username = options.configuration.get(NEXUS_IQ_USERNAME) + "";
       let maximumEvaluationPollAttempts = parseInt(
         options.configuration.get(NEXUS_IQ_MAX_EVAL_POLL_ATTEMPTS) + "", 10);
       this.applicationPublicId = options.configuration.get(NEXUS_IQ_PUBLIC_APPLICATION_ID) + "";
-      let password = options.configuration.get(NEXUS_IQ_USER_PASSWORD) + "";
+      this.password = options.configuration.get(NEXUS_IQ_USER_PASSWORD) + "";
       let strictSSL = options.configuration.get(NEXUS_IQ_STRICT_SSL) as boolean;
-      this.requestService = new IqRequestService(url, username, password, maximumEvaluationPollAttempts, strictSSL, options.logger);
+      this.requestService = new IqRequestService(this.url, this.username, this.password, maximumEvaluationPollAttempts, strictSSL, options.logger);
       this.logger = options.logger;
     }
   
@@ -66,7 +69,7 @@ export class IqComponentModel implements ComponentModel {
     }
   
     private async performIqScan(): Promise<any> {
-      return new Promise((resolve, reject) => {
+      return new Promise<void>((resolve, reject) => {
         try {
           let componentContainer = new ComponentContainer(this.logger);
 

--- a/ext-src/models/IqComponentModel.ts
+++ b/ext-src/models/IqComponentModel.ts
@@ -41,25 +41,23 @@ export class IqComponentModel implements ComponentModel {
       ComponentEntry
     >();
     requestService: RequestService;
-    dataSourceType: string;
     applicationPublicId: string;
-    url: string;
-    username: string;
-    password: string;
     private logger: ILogger;
   
     constructor(
       options: ComponentModelOptions
     ) {
-      this.dataSourceType = options.configuration.get(NEXUS_EXPLORER_DATA_SOURCE, "ossindex");
-      this.url = options.configuration.get(NEXUS_IQ_SERVER_URL) + "";
-      this.username = options.configuration.get(NEXUS_IQ_USERNAME) + "";
-      let maximumEvaluationPollAttempts = parseInt(
-        options.configuration.get(NEXUS_IQ_MAX_EVAL_POLL_ATTEMPTS) + "", 10);
       this.applicationPublicId = options.configuration.get(NEXUS_IQ_PUBLIC_APPLICATION_ID) + "";
-      this.password = options.configuration.get(NEXUS_IQ_USER_PASSWORD) + "";
-      let strictSSL = options.configuration.get(NEXUS_IQ_STRICT_SSL) as boolean;
-      this.requestService = new IqRequestService(this.url, this.username, this.password, maximumEvaluationPollAttempts, strictSSL, options.logger);
+
+      const url = options.configuration.get(NEXUS_IQ_SERVER_URL) + "";
+      const username = options.configuration.get(NEXUS_IQ_USERNAME) + "";
+      const  maximumEvaluationPollAttempts = parseInt(
+        options.configuration.get(NEXUS_IQ_MAX_EVAL_POLL_ATTEMPTS) + "", 10);
+      const password = options.configuration.get(NEXUS_IQ_USER_PASSWORD) + "";
+      const strictSSL = options.configuration.get(NEXUS_IQ_STRICT_SSL) as boolean;
+
+      this.requestService = new IqRequestService(url, username, password, maximumEvaluationPollAttempts, strictSSL, options.logger);
+      
       this.logger = options.logger;
     }
   

--- a/ext-src/services/IqRequestService.ts
+++ b/ext-src/services/IqRequestService.ts
@@ -17,7 +17,7 @@ import fetch from 'node-fetch';
 import { Headers } from 'node-fetch';
 import { RequestService } from "./RequestService";
 import { RequestHelpers } from "./RequestHelpers";
-import { Agent as HttpsAgent }  from "https";
+import { Agent as HttpsAgent, RequestOptions }  from "https";
 import { Agent } from 'http';
 import { ILogger, LogLevel } from '../utils/Logger';
 import { ThirdPartyAPIResponse } from './ThirdPartyApiResponse';
@@ -27,6 +27,7 @@ import { PackageURL } from 'packageurl-js';
 import { VulnerabilityResponse } from './VulnerabilityResponse';
 import { RemediationResponse } from './RemediationResponse';
 import { ApplicationResponse } from './ApplicationReponse';
+import { RefreshOptions } from '../NexusExplorer';
 
 export class IqRequestService implements RequestService {
   readonly evaluationPollDelayMs = 2000;
@@ -42,20 +43,32 @@ export class IqRequestService implements RequestService {
     readonly logger: ILogger
   ) 
   {
-    this.setUrl(url)
+    this.setUrl(url);
+
     this.logger.log(LogLevel.INFO, `Created new IQ Request Service at: `, url);
   }
 
-  public setUrl(url: string) {
-    if (url.endsWith("/")) {
-      this.url = url.replace(/\/$/, "");
+  public setOptions(options: RefreshOptions) {
+    if (options.url) {
+      this.setUrl(options.url);
     }
-    this.agent = this.getAgent(this.strictSSL, this.url.startsWith('https'));
-    this.logger.log(LogLevel.TRACE, `Setting IQ url to: `, this.url);
+    if (options.username) {
+      this.user = options.username;
+    }
+    if (options.token) { 
+      this.password = options.token;
+    }
   }
 
-  public setUser(user: string) {
-    this.user = user
+  private setUrl(url: string) {
+    this.logger.log(LogLevel.TRACE, `Setting IQ url to: `, this.url);
+
+    this.url = url.replace(/\/$/, "");
+
+    this.agent = this.getAgent(
+      this.strictSSL, 
+      this.url.startsWith('https')
+    );
   }
 
   public setPassword(password: string) {

--- a/ext-src/services/IqRequestService.ts
+++ b/ext-src/services/IqRequestService.ts
@@ -30,7 +30,7 @@ import { ApplicationResponse } from './ApplicationReponse';
 
 export class IqRequestService implements RequestService {
   readonly evaluationPollDelayMs = 2000;
-  private agent: Agent;
+  private agent: Agent = this.getAgent(false, false);
   applicationId: string = "";
 
   constructor(
@@ -42,12 +42,16 @@ export class IqRequestService implements RequestService {
     readonly logger: ILogger
   ) 
   {
+    this.setUrl(url)
+    this.logger.log(LogLevel.INFO, `Created new IQ Request Service at: `, url);
+  }
+
+  public setUrl(url: string) {
     if (url.endsWith("/")) {
       this.url = url.replace(/\/$/, "");
     }
-    this.logger.log(LogLevel.TRACE, `Creating new IQ Request Service`, url);
-
-    this.agent = this.getAgent(this.strictSSL, url.startsWith('https'));
+    this.agent = this.getAgent(this.strictSSL, this.url.startsWith('https'));
+    this.logger.log(LogLevel.TRACE, `Setting IQ url to: `, this.url);
   }
 
   public setUser(user: string) {

--- a/ext-src/services/IqRequestService.ts
+++ b/ext-src/services/IqRequestService.ts
@@ -50,6 +50,10 @@ export class IqRequestService implements RequestService {
     this.agent = this.getAgent(this.strictSSL, url.startsWith('https'));
   }
 
+  public setUser(user: string) {
+    this.user = user
+  }
+
   public setPassword(password: string) {
     this.password = password;
   }

--- a/ext-src/services/RequestService.ts
+++ b/ext-src/services/RequestService.ts
@@ -20,6 +20,7 @@ import { VulnerabilityResponse } from './VulnerabilityResponse';
 import { RemediationResponse } from './RemediationResponse';
 import { ComponentDetails } from './ComponentDetails';
 import { PackageURL } from 'packageurl-js';
+import { RefreshOptions } from "../NexusExplorer";
 
 export interface RequestService extends BaseRequestService {
   getApplicationId(applicationPublicId: string): Promise<string>;
@@ -31,8 +32,7 @@ export interface RequestService extends BaseRequestService {
   getVulnerabilityDetails(vulnID: string): Promise<VulnerabilityResponse>;
   getRemediation(purl: string): Promise<RemediationResponse>;
   showSelectedVersion(purl: string): Promise<ComponentDetails>
-  setUrl(user: string): void;
-  setUser(user: string): void;
+  setOptions(options: RefreshOptions): void;
   setPassword(password: string): void;
   isPasswordSet(): boolean;
   setApplicationId(s: string): void;

--- a/ext-src/services/RequestService.ts
+++ b/ext-src/services/RequestService.ts
@@ -31,6 +31,7 @@ export interface RequestService extends BaseRequestService {
   getVulnerabilityDetails(vulnID: string): Promise<VulnerabilityResponse>;
   getRemediation(purl: string): Promise<RemediationResponse>;
   showSelectedVersion(purl: string): Promise<ComponentDetails>
+  setUrl(user: string): void;
   setUser(user: string): void;
   setPassword(password: string): void;
   isPasswordSet(): boolean;

--- a/ext-src/services/RequestService.ts
+++ b/ext-src/services/RequestService.ts
@@ -31,6 +31,7 @@ export interface RequestService extends BaseRequestService {
   getVulnerabilityDetails(vulnID: string): Promise<VulnerabilityResponse>;
   getRemediation(purl: string): Promise<RemediationResponse>;
   showSelectedVersion(purl: string): Promise<ComponentDetails>
+  setUser(user: string): void;
   setPassword(password: string): void;
   isPasswordSet(): boolean;
   setApplicationId(s: string): void;

--- a/ext-src/utils/Config.ts
+++ b/ext-src/utils/Config.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2019-present Sonatype, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+const NEXUS_EXPLORER_BASE = "nexusExplorer";
+const NEXUS_IQ_BASE = "nexusIQ";
+
+const NEXUS_EXPLORER_DATA_SOURCE = NEXUS_EXPLORER_BASE.concat(".", "dataSource");
+const NEXUS_IQ_SERVER_URL = NEXUS_IQ_BASE.concat(".", "serverUrl");
+const NEXUS_IQ_USERNAME = NEXUS_IQ_BASE.concat(".", "username");
+const NEXUS_IQ_MAX_EVAL_POLL_ATTEMPTS = NEXUS_IQ_BASE.concat(".", "maximumEvaluationPollAttempts");
+const NEXUS_IQ_PUBLIC_APPLICATION_ID = NEXUS_IQ_BASE.concat(".", "applicationId");
+const NEXUS_IQ_USER_PASSWORD = NEXUS_IQ_BASE.concat(".", "userPassword");
+const NEXUS_IQ_STRICT_SSL = NEXUS_IQ_BASE.concat(".", "strictSSL");
+
+export {
+    NEXUS_EXPLORER_DATA_SOURCE,
+    NEXUS_IQ_SERVER_URL,
+    NEXUS_IQ_USERNAME,
+    NEXUS_IQ_MAX_EVAL_POLL_ATTEMPTS,
+    NEXUS_IQ_PUBLIC_APPLICATION_ID,
+    NEXUS_IQ_USER_PASSWORD,
+    NEXUS_IQ_STRICT_SSL
+};


### PR DESCRIPTION
Second verse same as the first. Change your Application ID, things refresh. 

This pull request makes the following changes:
* adds constants for all the config for IQ (OSS Index later)
* adds another check for if the config was changed for application ID
* adds a public method to NexusExplorer to update the application ID
* does some rewriting of how setup the config listener, and adds it to the context subscriptions, because it is a disposable!

cc @bhamail / @DarthHater 
