### PR TITLE
Add poetry.lock file to the theseAreTheLockFilesIKnow array in ConanU…

### DIFF
--- a/ext-src/packages/conan/ConanDependencies.ts
+++ b/ext-src/packages/conan/ConanDependencies.ts
@@ -26,7 +26,7 @@ import { ConanUtils } from "./ConanUtils";
 * @class ConanDependencies
 */
 export class ConanDependencies implements PackageDependencies {
-  private theseAreTheLockFilesIKnow: Array<string> = ["composer.lock", "Cargo.lock", "Gemfile.lock", "yarn.lock", "renv.lock"];
+  private theseAreTheLockFilesIKnow: Array<string> = ["composer.lock", "Cargo.lock", "Gemfile.lock", "yarn.lock", "renv.lock", "poetry.lock"];
 
   constructor(private options: PackageDependenciesOptions) {}
 


### PR DESCRIPTION
Conan format no longer mistakes a `poetry.lock` existing in a Python project for a conan lock file.

This pull request makes the following changes:
* Adds `poetry.lock` file to the known .lock files dependency list in ConanUtils.ts

cc @bhamail / @DarthHater @ButterB0wl 
