### PR TITLE
Switch over to main from master

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,7 @@ jobs:
           command: npm i -g vsce semantic-release @semantic-release/changelog @semantic-release/git@7.1.0-beta.11 @semantic-release/npm
       - run: 
           name: Attempt publish to GitHub
-          command: npx semantic-release -b master
+          command: npx semantic-release -b main
       - run: 
           name: Publish to Visual Studio Code Extension Marketplace
           command: vsce publish -p $VSCODE_TOKEN
@@ -51,7 +51,7 @@ workflows:
       - release:
           filters:
             branches:
-              only: master
+              only: main
           context: vscode-plugin
           requires:
             - build
@@ -62,6 +62,6 @@ workflows:
           cron: "20 20 * * *"
           filters:
             branches:
-              only: master
+              only: main
     jobs:
       - build

--- a/README.md
+++ b/README.md
@@ -131,13 +131,13 @@ We care a lot about making the world a safer place, and that's why we created th
 ## Releasing
 
 We use [semantic-release](https://github.com/semantic-release/semantic-release) to generate releases. For example,
-to perform a "patch" release, add a commit to master with a comment like:
+to perform a "patch" release, add a commit to main with a comment like:
 
 ```
 fix: `policyViolations of undefined` when loading a python project with requirements.txt (see Issue #127) 
 ```
 
-Without such a commit comment, commits to the `master` branch will cause a build failure during the release
+Without such a commit comment, commits to the `main` branch will cause a build failure during the release
 process due to an attempt to reuse an existing version number.
 
 To avoid such build failures without performing a release, be sure your commit message includes `[skip ci] `.

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "type": "git",
     "url": "https://github.com/sonatype-nexus-community/vscode-iq-plugin.git"
   },
-  "homepage": "https://github.com/sonatype-nexus-community/vscode-iq-plugin/blob/master/README.md",
+  "homepage": "https://github.com/sonatype-nexus-community/vscode-iq-plugin/blob/main/README.md",
   "bugs": {
     "url": "https://github.com/sonatype-nexus-community/vscode-iq-plugin/issues",
     "email": "community-group@sonatype.com"


### PR DESCRIPTION
I keep not doing this, and it makes me upset! Let's do this!

This pull request makes the following changes:
* Updates all mentions of `master` to `main`

Once this is merged, we SHOULD be able to just follow the rename directions here: https://github.com/github/renaming

cc @bhamail / @DarthHater 
