### PR TITLE
Pick up username or token from environment variables

### DIFF
--- a/ext-src/extension.ts
+++ b/ext-src/extension.ts
@@ -13,10 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {url} from 'inspector';
 import * as vscode from 'vscode';
 import { NexusExplorer } from './NexusExplorer';
-import { NEXUS_EXPLORER_DATA_SOURCE, NEXUS_IQ_PUBLIC_APPLICATION_ID, NEXUS_IQ_SERVER_URL, NEXUS_IQ_USERNAME, NEXUS_IQ_USER_PASSWORD } from './utils/Config';
+import { 
+	NEXUS_EXPLORER_DATA_SOURCE, 
+	NEXUS_IQ_PUBLIC_APPLICATION_ID, 
+	NEXUS_IQ_SERVER_URL, 
+	NEXUS_IQ_USERNAME, 
+	NEXUS_IQ_USER_PASSWORD } from './utils/Config';
 
 export function activate(context: vscode.ExtensionContext) {
 

--- a/ext-src/models/IqComponentModel.ts
+++ b/ext-src/models/IqComponentModel.ts
@@ -26,7 +26,6 @@ import { PackageType } from "../packages/PackageType";
 import { CycloneDXSbomCreator } from "../cyclonedx/CycloneDXGenerator";
 import { ReportResponse } from "../services/ReportResponse";
 import { 
-  NEXUS_EXPLORER_DATA_SOURCE, 
   NEXUS_IQ_MAX_EVAL_POLL_ATTEMPTS, 
   NEXUS_IQ_PUBLIC_APPLICATION_ID, 
   NEXUS_IQ_SERVER_URL, 
@@ -51,14 +50,13 @@ export class IqComponentModel implements ComponentModel {
     ) {
       this.applicationPublicId = options.configuration.get(NEXUS_IQ_PUBLIC_APPLICATION_ID) as string;
       this.url = options.configuration.get(NEXUS_IQ_SERVER_URL) as string;
-      const username = options.configuration.get(NEXUS_IQ_USERNAME) as string;
-      // this one is converted rather than cast as string
       const  maximumEvaluationPollAttempts = parseInt(
         String(options.configuration.get(NEXUS_IQ_MAX_EVAL_POLL_ATTEMPTS)), 10);
-      const password = options.configuration.get(NEXUS_IQ_USER_PASSWORD) as string;
       const strictSSL = options.configuration.get(NEXUS_IQ_STRICT_SSL) as boolean;
+      const username = (process.env.NEXUS_IQ_USERNAME ? process.env.NEXUS_IQ_USERNAME : options.configuration.get(NEXUS_IQ_USERNAME) as string);
+      const token = (process.env.NEXUS_IQ_TOKEN ? process.env.NEXUS_IQ_TOKEN : options.configuration.get(NEXUS_IQ_USER_PASSWORD) as string);
 
-      this.requestService = new IqRequestService(this.url, username, password, maximumEvaluationPollAttempts, strictSSL, options.logger);
+      this.requestService = new IqRequestService(this.url, username, token, maximumEvaluationPollAttempts, strictSSL, options.logger);
       
       this.logger = options.logger;
     }

--- a/ext-src/models/IqComponentModel.ts
+++ b/ext-src/models/IqComponentModel.ts
@@ -49,12 +49,13 @@ export class IqComponentModel implements ComponentModel {
       options: ComponentModelOptions
     ) {
       this.applicationPublicId = options.configuration.get(NEXUS_IQ_PUBLIC_APPLICATION_ID) as string;
-      this.url = options.configuration.get(NEXUS_IQ_SERVER_URL) as string;
+      this.url = (process.env.IQ_SERVER ? process.env.IQ_SERVER : options.configuration.get(NEXUS_IQ_SERVER_URL) as string);
+      const username = (process.env.IQ_USERNAME ? process.env.IQ_USERNAME : options.configuration.get(NEXUS_IQ_USERNAME) as string);
+      const token = (process.env.IQ_TOKEN ? process.env.IQ_TOKEN : options.configuration.get(NEXUS_IQ_USER_PASSWORD) as string);
+      
       const  maximumEvaluationPollAttempts = parseInt(
         String(options.configuration.get(NEXUS_IQ_MAX_EVAL_POLL_ATTEMPTS)), 10);
       const strictSSL = options.configuration.get(NEXUS_IQ_STRICT_SSL) as boolean;
-      const username = (process.env.NEXUS_IQ_USERNAME ? process.env.NEXUS_IQ_USERNAME : options.configuration.get(NEXUS_IQ_USERNAME) as string);
-      const token = (process.env.NEXUS_IQ_TOKEN ? process.env.NEXUS_IQ_TOKEN : options.configuration.get(NEXUS_IQ_USER_PASSWORD) as string);
 
       this.requestService = new IqRequestService(this.url, username, token, maximumEvaluationPollAttempts, strictSSL, options.logger);
       

--- a/ext-src/services/IqRequestService.ts
+++ b/ext-src/services/IqRequestService.ts
@@ -50,13 +50,13 @@ export class IqRequestService implements RequestService {
 
   public setOptions(options: RefreshOptions) {
     if (options.url) {
-      this.setUrl(options.url);
+      this.setUrl((process.env.IQ_SERVER ? process.env.IQ_SERVER : options.url));
     }
     if (options.username) {
-      this.user = options.username;
+      this.user = (process.env.IQ_USERNAME ? process.env.IQ_USERNAME : options.username);
     }
     if (options.token) { 
-      this.password = options.token;
+      this.password = (process.env.IQ_TOKEN ? process.env.IQ_TOKEN : options.token);
     }
   }
 

--- a/package.json
+++ b/package.json
@@ -159,7 +159,7 @@
           "nexusIQ.serverUrl": {
             "type": "string",
             "default": "http://127.0.0.1:8070",
-            "description": "URL (including port) of the Nexus IQ Server"
+            "description": "URL (including port) of the Nexus IQ Server (default: $IQ_SERVER from environment)"
           },
           "nexusIQ.strictSSL": {
             "type": "boolean",
@@ -169,12 +169,12 @@
           "nexusIQ.username": {
             "type": "string",
             "default": "admin",
-            "description": "Your Nexus IQ user name (default: $NEXUS_IQ_USERNAME from environment)"
+            "description": "Your Nexus IQ user name (default: $IQ_USERNAME from environment)"
           },
           "nexusIQ.userPassword": {
             "type": "string",
             "default": "admin123",
-            "description": "Your Nexus IQ password (default: $NEXUS_IQ_TOKEN from environment)"
+            "description": "Your Nexus IQ password (default: $IQ_TOKEN from environment)"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -159,7 +159,7 @@
           "nexusIQ.serverUrl": {
             "type": "string",
             "default": "http://127.0.0.1:8070",
-            "description": "URL (including port) of the Nexus IQ Server (default: $IQ_SERVER from environment)"
+            "description": "URL endpoint of the Nexus IQ Server (overridden by $IQ_SERVER from environment)"
           },
           "nexusIQ.strictSSL": {
             "type": "boolean",
@@ -169,12 +169,12 @@
           "nexusIQ.username": {
             "type": "string",
             "default": "admin",
-            "description": "Your Nexus IQ user name (default: $IQ_USERNAME from environment)"
+            "description": "Nexus IQ user name/token (overridden by $IQ_USERNAME from environment)"
           },
           "nexusIQ.userPassword": {
             "type": "string",
             "default": "admin123",
-            "description": "Your Nexus IQ password (default: $IQ_TOKEN from environment)"
+            "description": "Nexus IQ password (default: $IQ_TOKEN from environment)"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -169,12 +169,12 @@
           "nexusIQ.username": {
             "type": "string",
             "default": "admin",
-            "description": "Your Nexus IQ user name"
+            "description": "Your Nexus IQ user name (can be overriden with environment variable of NEXUS_IQ_USERNAME)"
           },
           "nexusIQ.userPassword": {
             "type": "string",
             "default": "admin123",
-            "description": "Your Nexus IQ password"
+            "description": "Your Nexus IQ password (can be overriden with environment variable of NEXUS_IQ_TOKEN)"
           }
         }
       }


### PR DESCRIPTION
Quick lil ditty that will pick up a username or token from environment variables:

`NEXUS_IQ_USERNAME`
`NEXUS_IQ_TOKEN`

This pull request makes the following changes:
* Minor tidy and switch to spaces in `extension.ts`
* Ternary that loads either the environment variable or the configuration for username/token

This will require a doc update, and potentially some nice UX stuff at some point, but quick a dirty to allow testing

(If there are changes to user behavior in general, please make sure to
update the docs, as well)

cc @bhamail / @DarthHater 
