### PR TITLE
Merge Process Environment on Exec Calls

### DIFF
--- a/ext-src/utils/exec.ts
+++ b/ext-src/utils/exec.ts
@@ -14,8 +14,11 @@
  * limitations under the License.
  */
 import * as cp from 'child_process';
+import * as process from 'process';
 
 export function exec(command: string, options: cp.ExecOptions): Promise<{ stdout: string; stderr: string }> {
+	options.env = { ...process.env, ...options.env }
+
 	return new Promise<{ stdout: string; stderr: string }>((resolve, reject) => {
 		cp.exec(command, options, (error, stdout, stderr) => {
 			if (error) {

--- a/ext-src/utils/exec.ts
+++ b/ext-src/utils/exec.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 import * as cp from 'child_process';
-import * as process from 'process';
 
 export function exec(command: string, options: cp.ExecOptions): Promise<{ stdout: string; stderr: string }> {
 	options.env = { ...process.env, ...options.env }


### PR DESCRIPTION
Configure any `exec` calls to use the VS Code process's environment variables in addition to any plugin-provided overrides.

This pull request makes the following changes:
Adjusts the `exec` function to incorporate VS Code process's environment variables.

(If there are changes to user behavior in general, please make sure to
update the docs, as well)

It relates to the following issue #s:
* Fixes 191

cc @bhamail / @DarthHater 
