### PR TITLE
Ensure url is set if loaded from config

### DIFF
--- a/ext-src/models/IqComponentModel.ts
+++ b/ext-src/models/IqComponentModel.ts
@@ -81,6 +81,8 @@ export class IqComponentModel implements ComponentModel {
         this.applicationPublicId = (doc.iq.PublicApplication ? doc.iq.PublicApplication : this.applicationPublicId);
         this.requestService.setStage((doc.iq.Stage ? doc.iq.Stage : DEFAULT_STAGE_VALUE));
         this.requestService.setURL((doc.iq.Server ? doc.iq.Server : this.url));
+        
+        this.url = (doc.iq.Server ? doc.iq.Server : this.url);
 
         this.logger.log(LogLevel.INFO, `Updated settings based on ${SONATYPE_CONFIG_FILE_NAME}`);
       }

--- a/package.json
+++ b/package.json
@@ -149,7 +149,7 @@
           "nexusIQ.applicationId": {
             "type": "string",
             "default": "sandbox-application",
-            "description": "Nexus IQ Application ID (overridden by .sonatyperc file)"
+            "description": "Nexus IQ Application ID (overridden by .sonatype-config file)"
           },
           "nexusIQ.maximumEvaluationPollAttempts": {
             "type": "number",
@@ -159,7 +159,7 @@
           "nexusIQ.serverUrl": {
             "type": "string",
             "default": "http://127.0.0.1:8070",
-            "description": "URL endpoint of Nexus IQ Server (overridden by .sonatyperc file)"
+            "description": "URL endpoint of Nexus IQ Server (overridden by .sonatype-config file)"
           },
           "nexusIQ.strictSSL": {
             "type": "boolean",


### PR DESCRIPTION
Quick bug fix that allows the URL to be populated for showing someone a link to their IQ Server Report

This pull request makes the following changes:
* Sets url to the `.sonatype-config` URL or the existing one.

cc @bhamail / @DarthHater 
