### PR TITLE
Only show policy tab on current version

### DIFF
--- a/src/ExtensionContainer.tsx
+++ b/src/ExtensionContainer.tsx
@@ -81,7 +81,9 @@ class ExtensionContainer extends React.Component<AppProps, AppState> {
               />
           </div>
           <div className="main">
-            <SelectedVersionDetails />
+            <SelectedVersionDetails 
+              selectedVersion={this.state.selectedVersion} 
+              currentVersion={this.state.initialVersion} />
           </div>
         </React.Fragment>
     </VersionsContextProvider>

--- a/src/components/IqServer/SelectedVersionDetails/SelectedVersionDetails.tsx
+++ b/src/components/IqServer/SelectedVersionDetails/SelectedVersionDetails.tsx
@@ -24,7 +24,12 @@ import {
   NxTabList, 
   NxTabPanel } from '@sonatype/react-shared-components';
 
-const SelectedVersionDetails = () => {
+type SelectedVersionProps = {
+  selectedVersion: string,
+  currentVersion: string
+}
+
+const SelectedVersionDetails = (props: SelectedVersionProps) => {
   const [activeTabId, setActiveTabId] = useState(0);
 
   return (
@@ -33,9 +38,11 @@ const SelectedVersionDetails = () => {
         <NxTab>
           Component Info
         </NxTab>
-        <NxTab>
-          Policy
-        </NxTab>
+        { props.currentVersion === props.selectedVersion && (
+          <NxTab>
+            Policy
+          </NxTab>
+        )}
         <NxTab>
           Security
         </NxTab>
@@ -46,9 +53,11 @@ const SelectedVersionDetails = () => {
       <NxTabPanel>
         <ComponentInfoPage></ComponentInfoPage>
       </NxTabPanel>
-      <NxTabPanel>
-        <PolicyPage></PolicyPage>
-      </NxTabPanel>
+      { props.currentVersion === props.selectedVersion && (
+        <NxTabPanel>
+          <PolicyPage></PolicyPage>
+        </NxTabPanel>
+      )}
       <NxTabPanel>
         <SecurityPage></SecurityPage>
       </NxTabPanel>


### PR DESCRIPTION
Based on a suggestion from @maurycupitt and @ButterB0wl , here's a PR that only shows Policy if you are looking at the version you ran the IQ scan against

This pull request makes the following changes:
* Adds props to `SelectedVersionDetails` for current and selectedVersion
* Implements a quick if check on those to render the Policy

cc @bhamail / @DarthHater 
