### PR TITLE
fix: updated parsing logic for `mvn dependency:tree` output to exclude items reported as " ommitted for "

### DIFF
--- a/ext-src/packages/maven/MavenUtils.ts
+++ b/ext-src/packages/maven/MavenUtils.ts
@@ -74,6 +74,7 @@ export class MavenUtils {
     // console.debug(
     //   "------------------------------------------------------------------------------"
     // );
+
     let dependencyList: MavenPackage[] = [];
     let dependencyListString: Set<string> = new Set<string>();
 
@@ -81,7 +82,9 @@ export class MavenUtils {
     dependencyLines.forEach((dep, index) => {
       if (index > 0) {
         if (dep.trim()) {
-          if (dep.includes("omitted for duplicate")) {
+          console.log(`Parsing dep: ${dep}`)
+          if (dep.includes(" omitted for ")) {
+            console.log(`Skipping dep: ${dep}`)
             return;
           }
           const dependencyParts: string[] = dep.trim().split(":");


### PR DESCRIPTION
Signed-off-by: Paul Horton <phorton@sonatype.com>

Updated parsing of `mvn dependency:tree` output. We were specifically excluding items "omitted for duplicate", but this left comment items that were "omitted for conflict with...".

For the example project in #85 ([cyclonedx-maven-plugin](https://github.com/CycloneDX/cyclonedx-maven-plugin)), the following lines were seen in the output from `mvn dependency:tree`:

```
...
|  |  +- org.codehaus.woodstox:stax2-api:jar:4.2.1:compile
|  |  \- com.fasterxml.woodstox:woodstox-core:jar:6.2.4:compile
|  |     \- (org.codehaus.woodstox:stax2-api:jar:4.2.1:compile - omitted for duplicate)
|  +- com.networknt:json-schema-validator:jar:1.0.58:compile
|  |  +- (com.fasterxml.jackson.core:jackson-databind:jar:2.12.1:compile - omitted for conflict with 2.12.4)
...
```

Prior to this change, the last line with "omitted for conflict..." was not stripped out during parsing which caused errors.

It relates to the following issue #s:
* Fixes #85 

cc @bhamail / @DarthHater 
