### PR TITLE
fix: change so that `gradlew` has priority over `gradle`

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ Good news for polyglots -- the extension allows you to view violations across mu
 - Conan (any conan formatted `*.lock` files)
 - Golang (`dep` or `go mod`)
 - Gradle (`build.gradle` and gradle required) *Supports development dependency exclusion*
+  - Note: `./gradlew` or `./gradlew.bat` will take precedence over system `gradle`
+  - Note: Android projects are not currently supported
 - Maven (`pom.xml` and maven required) *Supports development dependency exclusion*
 - NPM/Yarn (`npm install` or `yarn install` required) *Supports development dependency exclusion*
 - Python:

--- a/ext-src/models/ComponentEntry.ts
+++ b/ext-src/models/ComponentEntry.ts
@@ -43,7 +43,7 @@ export class ComponentEntry implements TreeableModel {
   }
 
   public toString(): string {
-    return `${this.application.name}: ${this.format}: ${this.name} @ ${this.version}`;
+    return `${this.format}: ${this.name} @ ${this.version}`;
   }
 
   public maxPolicy(): number {

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,9 +36,9 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.15.4",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.15.4.tgz",
-      "integrity": "sha512-99catp6bHCaxr4sJ/DbTGgHS4+Rs2RVd2g7iOap6SLGPDknRK9ztKNsE/Fg6QhSeh1FGE5f6gHGQmvvn3I3xhw==",
+      "version": "7.16.7",
+      "resolved": "http://repo.localhost/repository/npm/@babel/runtime/-/runtime-7.16.7.tgz",
+      "integrity": "sha512-9E9FJowqAsytyOY6LG+1KuueckRL+aQW+mKvXRXnuFGyRAyepJPmEo9vgMfXUA6O9u3IeEdv9MAkppFcaQwogQ==",
       "requires": {
         "regenerator-runtime": "^0.13.4"
       }
@@ -51,7 +51,7 @@
     },
     "@emotion/hash": {
       "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.8.0.tgz",
+      "resolved": "http://repo.localhost/repository/npm/@emotion/hash/-/hash-0.8.0.tgz",
       "integrity": "sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow=="
     },
     "@fortawesome/fontawesome-common-types": {
@@ -61,8 +61,16 @@
     },
     "@fortawesome/fontawesome-svg-core": {
       "version": "1.2.36",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-1.2.36.tgz",
+      "resolved": "http://repo.localhost/repository/npm/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-1.2.36.tgz",
       "integrity": "sha512-YUcsLQKYb6DmaJjIHdDWpBIGCcyE/W+p/LMGvjQem55Mm2XWVAP5kWTMKWLv9lwpCVjpLxPyOMOyUocP1GxrtA==",
+      "requires": {
+        "@fortawesome/fontawesome-common-types": "^0.2.36"
+      }
+    },
+    "@fortawesome/free-regular-svg-icons": {
+      "version": "5.15.4",
+      "resolved": "http://repo.localhost/repository/npm/@fortawesome/free-regular-svg-icons/-/free-regular-svg-icons-5.15.4.tgz",
+      "integrity": "sha512-9VNNnU3CXHy9XednJ3wzQp6SwNwT3XaM26oS4Rp391GsxVYA+0oDR2J194YCIWf7jNRCYKjUCOduxdceLrx+xw==",
       "requires": {
         "@fortawesome/fontawesome-common-types": "^0.2.36"
       }
@@ -76,21 +84,21 @@
       }
     },
     "@fortawesome/react-fontawesome": {
-      "version": "0.1.15",
-      "resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-0.1.15.tgz",
-      "integrity": "sha512-/HFHdcoLESxxMkqZAcZ6RXDJ69pVApwdwRos/B2kiMWxDSAX2dFK8Er2/+rG+RsrzWB/dsAyjefLmemgmfE18g==",
+      "version": "0.1.16",
+      "resolved": "http://repo.localhost/repository/npm/@fortawesome/react-fontawesome/-/react-fontawesome-0.1.16.tgz",
+      "integrity": "sha512-aLmzDwC9rEOAJv2UJdMns89VZR5Ry4IHu5dQQh24Z/lWKEm44lfQr1UNalZlkUaQN8d155tNh+CS7ntntj1VMA==",
       "requires": {
         "prop-types": "^15.7.2"
       }
     },
     "@juggle/resize-observer": {
       "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@juggle/resize-observer/-/resize-observer-3.3.1.tgz",
+      "resolved": "http://repo.localhost/repository/npm/@juggle/resize-observer/-/resize-observer-3.3.1.tgz",
       "integrity": "sha512-zMM9Ds+SawiUkakS7y94Ymqx+S0ORzpG3frZirN3l+UlXUmSUR7hF4wxCVqW+ei94JzV5kt0uXBcoOEAuiydrw=="
     },
     "@material-ui/core": {
       "version": "4.12.3",
-      "resolved": "https://registry.npmjs.org/@material-ui/core/-/core-4.12.3.tgz",
+      "resolved": "http://repo.localhost/repository/npm/@material-ui/core/-/core-4.12.3.tgz",
       "integrity": "sha512-sdpgI/PL56QVsEJldwEe4FFaFTLUqN+rd7sSZiRCdx2E/C7z5yK0y/khAWVBH24tXwto7I1hCzNWfJGZIYJKnw==",
       "requires": {
         "@babel/runtime": "^7.4.4",
@@ -109,7 +117,7 @@
     },
     "@material-ui/styles": {
       "version": "4.11.4",
-      "resolved": "https://registry.npmjs.org/@material-ui/styles/-/styles-4.11.4.tgz",
+      "resolved": "http://repo.localhost/repository/npm/@material-ui/styles/-/styles-4.11.4.tgz",
       "integrity": "sha512-KNTIZcnj/zprG5LW0Sao7zw+yG3O35pviHzejMdcSGCdWbiO8qzRgOYL8JAxAsWBKOKYwVZxXtHWaB5T2Kvxew==",
       "requires": {
         "@babel/runtime": "^7.4.4",
@@ -132,7 +140,7 @@
     },
     "@material-ui/system": {
       "version": "4.12.1",
-      "resolved": "https://registry.npmjs.org/@material-ui/system/-/system-4.12.1.tgz",
+      "resolved": "http://repo.localhost/repository/npm/@material-ui/system/-/system-4.12.1.tgz",
       "integrity": "sha512-lUdzs4q9kEXZGhbN7BptyiS1rLNHe6kG9o8Y307HCvF4sQxbCgpL2qi+gUk+yI8a2DNk48gISEQxoxpgph0xIw==",
       "requires": {
         "@babel/runtime": "^7.4.4",
@@ -143,12 +151,12 @@
     },
     "@material-ui/types": {
       "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@material-ui/types/-/types-5.1.0.tgz",
+      "resolved": "http://repo.localhost/repository/npm/@material-ui/types/-/types-5.1.0.tgz",
       "integrity": "sha512-7cqRjrY50b8QzRSYyhSpx4WRw2YuO0KKIGQEVk5J8uoz2BanawykgZGoWEqKm7pVIbzFDN0SpPcVV4IhOFkl8A=="
     },
     "@material-ui/utils": {
       "version": "4.11.2",
-      "resolved": "https://registry.npmjs.org/@material-ui/utils/-/utils-4.11.2.tgz",
+      "resolved": "http://repo.localhost/repository/npm/@material-ui/utils/-/utils-4.11.2.tgz",
       "integrity": "sha512-Uul8w38u+PICe2Fg2pDKCaIG7kOyhowZ9vjiC1FsVwPABTW8vPPKfF6OvxRq3IiBaI1faOJmgdvMG7rMJARBhA==",
       "requires": {
         "@babel/runtime": "^7.4.4",
@@ -158,23 +166,23 @@
     },
     "@react-hook/latest": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@react-hook/latest/-/latest-1.0.3.tgz",
+      "resolved": "http://repo.localhost/repository/npm/@react-hook/latest/-/latest-1.0.3.tgz",
       "integrity": "sha512-dy6duzl+JnAZcDbNTfmaP3xHiKtbXYOaz3G51MGVljh548Y8MWzTr+PHLOfvpypEVW9zwvl+VyKjbWKEVbV1Rg=="
     },
     "@react-hook/merged-ref": {
       "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@react-hook/merged-ref/-/merged-ref-1.3.2.tgz",
+      "resolved": "http://repo.localhost/repository/npm/@react-hook/merged-ref/-/merged-ref-1.3.2.tgz",
       "integrity": "sha512-cQ9Y8m4zlrw/qotReo33E+3Sy9FVqMZb5JwUlb3wj3IJJ1cNJtxcgfWF6rS2NZQrfBJ2nAnckUdPJjMyIJTNZg=="
     },
     "@react-hook/passive-layout-effect": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@react-hook/passive-layout-effect/-/passive-layout-effect-1.2.1.tgz",
+      "resolved": "http://repo.localhost/repository/npm/@react-hook/passive-layout-effect/-/passive-layout-effect-1.2.1.tgz",
       "integrity": "sha512-IwEphTD75liO8g+6taS+4oqz+nnroocNfWVHWz7j+N+ZO2vYrc6PV1q7GQhuahL0IOR7JccFTsFKQ/mb6iZWAg=="
     },
     "@react-hook/resize-observer": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@react-hook/resize-observer/-/resize-observer-1.2.4.tgz",
-      "integrity": "sha512-ouYbtX9kcwG6a52cl2JiIm2e846bQ00RZ/3ATs7yDke/4Z/SG/+SWU8WTdCcBBS4R25nhBsbAjWdd85kHuhO6g==",
+      "version": "1.2.5",
+      "resolved": "http://repo.localhost/repository/npm/@react-hook/resize-observer/-/resize-observer-1.2.5.tgz",
+      "integrity": "sha512-qa0pPvRxq5VbdI8mMK2apPFsZOckhQ6D3Jc9yLuyHMNhui8yEih4qyFCZBDzzK3ymZS6LAltVSVg3l1Dg9vA0w==",
       "requires": {
         "@juggle/resize-observer": "^3.3.1",
         "@react-hook/latest": "^1.0.2",
@@ -185,12 +193,12 @@
     },
     "@rooks/use-mutation-observer": {
       "version": "4.11.2",
-      "resolved": "https://registry.npmjs.org/@rooks/use-mutation-observer/-/use-mutation-observer-4.11.2.tgz",
+      "resolved": "http://repo.localhost/repository/npm/@rooks/use-mutation-observer/-/use-mutation-observer-4.11.2.tgz",
       "integrity": "sha512-vpsdrZdr6TkB1zZJcHx+fR1YC/pHs2BaqcuYiEGjBVbwY5xcC49+h0hAUtQKHth3oJqXfIX/Ng8S7s5HFHdM/A=="
     },
     "@sonatype/commonmark-react-renderer": {
       "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/@sonatype/commonmark-react-renderer/-/commonmark-react-renderer-4.3.6.tgz",
+      "resolved": "http://repo.localhost/repository/npm/@sonatype/commonmark-react-renderer/-/commonmark-react-renderer-4.3.6.tgz",
       "integrity": "sha512-MA6p6SR9nOCdELtYLOGWBNMHyQOJitIHuu024w77rPAhhV7Ut7//vseoDrypyeHJJf0qJ6wGSc67TC7xkmplsg==",
       "requires": {
         "lodash.assign": "^4.2.0",
@@ -201,7 +209,7 @@
     },
     "@sonatype/react-commonmark": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@sonatype/react-commonmark/-/react-commonmark-3.0.1.tgz",
+      "resolved": "http://repo.localhost/repository/npm/@sonatype/react-commonmark/-/react-commonmark-3.0.1.tgz",
       "integrity": "sha512-jI3q4Ss/tn5xMOvU2xyskRgnd1DmsUDqxqrleMrAgg5bA/2QM/3xQ7P4X5qK5pofqCpA34ifaXgeDrkFX5DfoQ==",
       "requires": {
         "@sonatype/commonmark-react-renderer": "^4.3.6",
@@ -211,12 +219,13 @@
       }
     },
     "@sonatype/react-shared-components": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/@sonatype/react-shared-components/-/react-shared-components-9.0.1.tgz",
-      "integrity": "sha512-dzXmtPwAOJs6zUhlFd7n1bWc/b2OF310URj1g9/ac3axyms67yqJtfWBnqPHHYsqLgenC4TMeItsakcofeHlmQ==",
+      "version": "9.5.15",
+      "resolved": "http://repo.localhost/repository/npm/@sonatype/react-shared-components/-/react-shared-components-9.5.15.tgz",
+      "integrity": "sha512-4YD5zT0sT89Mln0fTHKPFispU1SjmGsOqRIXKjemokikyvmQRXb4B0pT6O8wrBBzqtJ8HUe7TLfAMcHfMP6bJA==",
       "requires": {
         "@fortawesome/fontawesome-svg-core": "^1.2.32",
-        "@fortawesome/free-solid-svg-icons": "^5.15.1",
+        "@fortawesome/free-regular-svg-icons": "^5.15.4",
+        "@fortawesome/free-solid-svg-icons": "^5.15.4",
         "@fortawesome/react-fontawesome": "^0.1.14",
         "@material-ui/core": "^4.11.2",
         "@react-hook/merged-ref": "^1.3.0",
@@ -234,14 +243,14 @@
       "dependencies": {
         "@types/prop-types": {
           "version": "15.7.4",
-          "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.4.tgz",
+          "resolved": "http://repo.localhost/repository/npm/@types/prop-types/-/prop-types-15.7.4.tgz",
           "integrity": "sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ=="
         }
       }
     },
     "@types/classnames": {
       "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@types/classnames/-/classnames-2.3.1.tgz",
+      "resolved": "http://repo.localhost/repository/npm/@types/classnames/-/classnames-2.3.1.tgz",
       "integrity": "sha512-zeOWb0JGBoVmlQoznvqXbE0tEC/HONsnoUNH19Hc96NFsTAwTXbTqb8FMYkru1F/iqp7a18Ws3nWJvtA1sHD1A==",
       "requires": {
         "classnames": "*"
@@ -335,13 +344,13 @@
     },
     "@types/raf-schd": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@types/raf-schd/-/raf-schd-4.0.1.tgz",
+      "resolved": "http://repo.localhost/repository/npm/@types/raf-schd/-/raf-schd-4.0.1.tgz",
       "integrity": "sha512-Ha+EnKHFIh9EKW0/XZJPUd3EGDFisEvauaBd4VVCRPKeOqUxNEc9TodiY2Zhk33XCgzJucoFEcaoNcBAPHTQ2A=="
     },
     "@types/ramda": {
-      "version": "0.27.45",
-      "resolved": "https://registry.npmjs.org/@types/ramda/-/ramda-0.27.45.tgz",
-      "integrity": "sha512-WDH7bIuy+JQHzYx6jgo+ytSHco/J+DWaUfxXQ2eBjilxIj4rG0aqQNU56AtO5Tem9hmx8na2ouSAtn5Tz8RePQ==",
+      "version": "0.27.63",
+      "resolved": "http://repo.localhost/repository/npm/@types/ramda/-/ramda-0.27.63.tgz",
+      "integrity": "sha512-gG8P2Y54L1O0Q4fz+y93BJZ6//p1kyvej1hFFsmPk4A/bnB6twY/5SYYmavxlhby5uB5GPYVrrREH9BTaocAjw==",
       "requires": {
         "ts-toolbelt": "^6.15.1"
       }
@@ -373,9 +382,9 @@
       }
     },
     "@types/react-transition-group": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.3.tgz",
-      "integrity": "sha512-fUx5muOWSYP8Bw2BUQ9M9RK9+W1XBK/7FLJ8PTQpnpTEkn0ccyMffyEQvan4C3h53gHdx7KE5Qrxi/LnUGQtdg==",
+      "version": "4.4.4",
+      "resolved": "http://repo.localhost/repository/npm/@types/react-transition-group/-/react-transition-group-4.4.4.tgz",
+      "integrity": "sha512-7gAPz7anVK5xzbeQW9wFBDg7G++aPLAFY0QaSMOou9rJZpbuI58WAuJrgu+qR92l61grlnCUe7AFX8KGahAgug==",
       "requires": {
         "@types/react": "*"
       }
@@ -795,7 +804,7 @@
     },
     "classnames": {
       "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.1.tgz",
+      "resolved": "http://repo.localhost/repository/npm/classnames/-/classnames-2.3.1.tgz",
       "integrity": "sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA=="
     },
     "clean-css": {
@@ -831,7 +840,7 @@
     },
     "clsx": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.1.1.tgz",
+      "resolved": "http://repo.localhost/repository/npm/clsx/-/clsx-1.1.1.tgz",
       "integrity": "sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA=="
     },
     "color-convert": {
@@ -875,7 +884,7 @@
     },
     "commonmark": {
       "version": "0.29.3",
-      "resolved": "https://registry.npmjs.org/commonmark/-/commonmark-0.29.3.tgz",
+      "resolved": "http://repo.localhost/repository/npm/commonmark/-/commonmark-0.29.3.tgz",
       "integrity": "sha512-fvt/NdOFKaL2gyhltSy6BC4LxbbxbnPxBMl923ittqO/JBM0wQHaoYZliE4tp26cRxX/ZZtRsJlZzQrVdUkXAA==",
       "requires": {
         "entities": "~2.0",
@@ -950,7 +959,7 @@
     },
     "css-vendor": {
       "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/css-vendor/-/css-vendor-2.0.8.tgz",
+      "resolved": "http://repo.localhost/repository/npm/css-vendor/-/css-vendor-2.0.8.tgz",
       "integrity": "sha512-x9Aq0XTInxrkuFeHKbYC7zWY8ai7qJ04Kxd9MnvbC1uO5DagxoHQjm4JvG+vCdXOoFtCjbL2XSZfxmoYa9uQVQ==",
       "requires": {
         "@babel/runtime": "^7.8.3",
@@ -970,9 +979,9 @@
       "dev": true
     },
     "csstype": {
-      "version": "2.6.18",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.18.tgz",
-      "integrity": "sha512-RSU6Hyeg14am3Ah4VZEmeX8H7kLwEEirXe6aU2IPfKNvhXwTflK5HQRDNI0ypQXoqmm+QPyG2IaPuQE5zMwSIQ=="
+      "version": "2.6.19",
+      "resolved": "http://repo.localhost/repository/npm/csstype/-/csstype-2.6.19.tgz",
+      "integrity": "sha512-ZVxXaNy28/k3kJg0Fou5MiYpp88j7H9hLZp8PDC3jV0WFjfH5E9xHb56L0W59cPbKbcHXeP4qyT8PrHp8t6LcQ=="
     },
     "date-format": {
       "version": "3.0.0",
@@ -1012,7 +1021,7 @@
     },
     "dom-helpers": {
       "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
+      "resolved": "http://repo.localhost/repository/npm/dom-helpers/-/dom-helpers-5.2.1.tgz",
       "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
       "requires": {
         "@babel/runtime": "^7.8.7",
@@ -1020,9 +1029,9 @@
       },
       "dependencies": {
         "csstype": {
-          "version": "3.0.9",
-          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.9.tgz",
-          "integrity": "sha512-rpw6JPxK6Rfg1zLOYCSwle2GFOOsnjmDYDaBwEcwoOg4qlsIVCN789VkBZDJAGi4T07gI4YSutR43t9Zz4Lzuw=="
+          "version": "3.0.10",
+          "resolved": "http://repo.localhost/repository/npm/csstype/-/csstype-3.0.10.tgz",
+          "integrity": "sha512-2u44ZG2OcNUO9HDp/Jl8C07x6pU/eTR3ncV91SiK3dhG9TWvRVsCoJw14Ckx5DgWkzGA3waZWO3d7pgqpUI/XA=="
         }
       }
     },
@@ -1114,7 +1123,7 @@
     },
     "entities": {
       "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-2.0.3.tgz",
+      "resolved": "http://repo.localhost/repository/npm/entities/-/entities-2.0.3.tgz",
       "integrity": "sha512-MyoZ0jgnLvB2X3Lg5HqpFmn1kybDiIfEQmKzTb5apr51Rb+T3KdmMiqa70T+bhGnyv7bQ6WMj2QMHpGMmlrUYQ=="
     },
     "envinfo": {
@@ -1331,9 +1340,9 @@
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
     },
     "fuse.js": {
-      "version": "6.4.6",
-      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-6.4.6.tgz",
-      "integrity": "sha512-/gYxR/0VpXmWSfZOIPS3rWwU8SHgsRTwWuXhyb2O6s7aRuVtHtxCkR33bNYu3wyLyNx/Wpv0vU7FZy8Vj53VNw=="
+      "version": "6.5.3",
+      "resolved": "http://repo.localhost/repository/npm/fuse.js/-/fuse.js-6.5.3.tgz",
+      "integrity": "sha512-sA5etGE7yD/pOqivZRBvUBd/NaL2sjAu6QuSaFoe1H2BrJSkH/T/UXAJ8CdXdw7DvY3Hs8CXKYkDWX7RiP5KOg=="
     },
     "gemfile": {
       "version": "1.1.0",
@@ -1437,7 +1446,7 @@
     },
     "hoist-non-react-statics": {
       "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "resolved": "http://repo.localhost/repository/npm/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
       "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
       "requires": {
         "react-is": "^16.7.0"
@@ -1504,7 +1513,7 @@
     },
     "hyphenate-style-name": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.0.4.tgz",
+      "resolved": "http://repo.localhost/repository/npm/hyphenate-style-name/-/hyphenate-style-name-1.0.4.tgz",
       "integrity": "sha512-ygGZLjmXfPHj+ZWh6LwbC37l43MhfztxetbFCoYTM2VjkIUpeHgSNn7QIyVFj7YQ1Wl9Cbw5sholVJPzWvC2MQ=="
     },
     "icss-utils": {
@@ -1525,7 +1534,7 @@
     },
     "in-publish": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/in-publish/-/in-publish-2.0.1.tgz",
+      "resolved": "http://repo.localhost/repository/npm/in-publish/-/in-publish-2.0.1.tgz",
       "integrity": "sha512-oDM0kUSNFC31ShNxHKUyfZKy8ZeXZBWMjMdZHKLOk13uvT27VTL/QzRGfRUcevJhpkZAvlhPYuXkF7eNWrtyxQ=="
     },
     "inflight": {
@@ -1627,7 +1636,7 @@
     },
     "is-in-browser": {
       "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/is-in-browser/-/is-in-browser-1.1.3.tgz",
+      "resolved": "http://repo.localhost/repository/npm/is-in-browser/-/is-in-browser-1.1.3.tgz",
       "integrity": "sha1-Vv9NtoOgeMYILrldrX3GLh0E+DU="
     },
     "is-negative-zero": {
@@ -1787,9 +1796,9 @@
       }
     },
     "jss": {
-      "version": "10.8.1",
-      "resolved": "https://registry.npmjs.org/jss/-/jss-10.8.1.tgz",
-      "integrity": "sha512-P4wKxU+2m5ReGl0Mmbf9XYgVjFIVZJOZ9ylXBxdpanX+HHgj5XVaAIgYzYpKbBLPCdkAUsI/Iq1fhQPsMNu0YA==",
+      "version": "10.9.0",
+      "resolved": "http://repo.localhost/repository/npm/jss/-/jss-10.9.0.tgz",
+      "integrity": "sha512-YpzpreB6kUunQBbrlArlsMpXYyndt9JATbt95tajx0t4MTJJcCJdd4hdNpHmOIDiUJrF/oX5wtVFrS3uofWfGw==",
       "requires": {
         "@babel/runtime": "^7.3.1",
         "csstype": "^3.0.2",
@@ -1798,77 +1807,77 @@
       },
       "dependencies": {
         "csstype": {
-          "version": "3.0.9",
-          "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.9.tgz",
-          "integrity": "sha512-rpw6JPxK6Rfg1zLOYCSwle2GFOOsnjmDYDaBwEcwoOg4qlsIVCN789VkBZDJAGi4T07gI4YSutR43t9Zz4Lzuw=="
+          "version": "3.0.10",
+          "resolved": "http://repo.localhost/repository/npm/csstype/-/csstype-3.0.10.tgz",
+          "integrity": "sha512-2u44ZG2OcNUO9HDp/Jl8C07x6pU/eTR3ncV91SiK3dhG9TWvRVsCoJw14Ckx5DgWkzGA3waZWO3d7pgqpUI/XA=="
         }
       }
     },
     "jss-plugin-camel-case": {
-      "version": "10.8.1",
-      "resolved": "https://registry.npmjs.org/jss-plugin-camel-case/-/jss-plugin-camel-case-10.8.1.tgz",
-      "integrity": "sha512-nOYKsvX9qh/AcUWSSRZHKyUj4RwqnhUSq4EKNFA1nHsNw0VJYwtF1yqtOPvztWEP3LTlNhcwoPINsb/eKVmYqA==",
+      "version": "10.9.0",
+      "resolved": "http://repo.localhost/repository/npm/jss-plugin-camel-case/-/jss-plugin-camel-case-10.9.0.tgz",
+      "integrity": "sha512-UH6uPpnDk413/r/2Olmw4+y54yEF2lRIV8XIZyuYpgPYTITLlPOsq6XB9qeqv+75SQSg3KLocq5jUBXW8qWWww==",
       "requires": {
         "@babel/runtime": "^7.3.1",
         "hyphenate-style-name": "^1.0.3",
-        "jss": "10.8.1"
+        "jss": "10.9.0"
       }
     },
     "jss-plugin-default-unit": {
-      "version": "10.8.1",
-      "resolved": "https://registry.npmjs.org/jss-plugin-default-unit/-/jss-plugin-default-unit-10.8.1.tgz",
-      "integrity": "sha512-W/uwVJNrFtUrVyAPfH/3ZngFYUVilMxgNbuWHYslqv3c5gnBKM6iXeoDzOnB+wtQJoSCTLzD3q77H7OeNK3oxg==",
+      "version": "10.9.0",
+      "resolved": "http://repo.localhost/repository/npm/jss-plugin-default-unit/-/jss-plugin-default-unit-10.9.0.tgz",
+      "integrity": "sha512-7Ju4Q9wJ/MZPsxfu4T84mzdn7pLHWeqoGd/D8O3eDNNJ93Xc8PxnLmV8s8ZPNRYkLdxZqKtm1nPQ0BM4JRlq2w==",
       "requires": {
         "@babel/runtime": "^7.3.1",
-        "jss": "10.8.1"
+        "jss": "10.9.0"
       }
     },
     "jss-plugin-global": {
-      "version": "10.8.1",
-      "resolved": "https://registry.npmjs.org/jss-plugin-global/-/jss-plugin-global-10.8.1.tgz",
-      "integrity": "sha512-ERYLzD+L/v3yQL2mM5/PE+3xU/GCXcfXuGIL1kVkiEIpXnWtND/Mphf2iHQaqedx59uhiVHFZaMtv6qv+iNsDw==",
+      "version": "10.9.0",
+      "resolved": "http://repo.localhost/repository/npm/jss-plugin-global/-/jss-plugin-global-10.9.0.tgz",
+      "integrity": "sha512-4G8PHNJ0x6nwAFsEzcuVDiBlyMsj2y3VjmFAx/uHk/R/gzJV+yRHICjT4MKGGu1cJq2hfowFWCyrr/Gg37FbgQ==",
       "requires": {
         "@babel/runtime": "^7.3.1",
-        "jss": "10.8.1"
+        "jss": "10.9.0"
       }
     },
     "jss-plugin-nested": {
-      "version": "10.8.1",
-      "resolved": "https://registry.npmjs.org/jss-plugin-nested/-/jss-plugin-nested-10.8.1.tgz",
-      "integrity": "sha512-Z15G23Fb8/br23EclH9CAq2UGdi29XgpSWXFTBusMJbWjitFdDCdYMzk7bSUJ6P7L5+WpaIDNxIJ9WrdMRqdXw==",
+      "version": "10.9.0",
+      "resolved": "http://repo.localhost/repository/npm/jss-plugin-nested/-/jss-plugin-nested-10.9.0.tgz",
+      "integrity": "sha512-2UJnDrfCZpMYcpPYR16oZB7VAC6b/1QLsRiAutOt7wJaaqwCBvNsosLEu/fUyKNQNGdvg2PPJFDO5AX7dwxtoA==",
       "requires": {
         "@babel/runtime": "^7.3.1",
-        "jss": "10.8.1",
+        "jss": "10.9.0",
         "tiny-warning": "^1.0.2"
       }
     },
     "jss-plugin-props-sort": {
-      "version": "10.8.1",
-      "resolved": "https://registry.npmjs.org/jss-plugin-props-sort/-/jss-plugin-props-sort-10.8.1.tgz",
-      "integrity": "sha512-BNbKYuh4IawWr7cticlnbI+kBx01o39DNHkjAkc2CGKWVboUb2EpktDqonqVN/BjyzDgZXKOmwz36ZFkLQB45g==",
+      "version": "10.9.0",
+      "resolved": "http://repo.localhost/repository/npm/jss-plugin-props-sort/-/jss-plugin-props-sort-10.9.0.tgz",
+      "integrity": "sha512-7A76HI8bzwqrsMOJTWKx/uD5v+U8piLnp5bvru7g/3ZEQOu1+PjHvv7bFdNO3DwNPC9oM0a//KwIJsIcDCjDzw==",
       "requires": {
         "@babel/runtime": "^7.3.1",
-        "jss": "10.8.1"
+        "jss": "10.9.0"
       }
     },
     "jss-plugin-rule-value-function": {
-      "version": "10.8.1",
-      "resolved": "https://registry.npmjs.org/jss-plugin-rule-value-function/-/jss-plugin-rule-value-function-10.8.1.tgz",
-      "integrity": "sha512-XrvM4bokyU1xPXr+gVEIlT9WylLQZcdC+1JDxriXDEWmKEjJgtH+w6ZicchTydLqq1qtA4fEevhdMvm4QvgIKw==",
+      "version": "10.9.0",
+      "resolved": "http://repo.localhost/repository/npm/jss-plugin-rule-value-function/-/jss-plugin-rule-value-function-10.9.0.tgz",
+      "integrity": "sha512-IHJv6YrEf8pRzkY207cPmdbBstBaE+z8pazhPShfz0tZSDtRdQua5jjg6NMz3IbTasVx9FdnmptxPqSWL5tyJg==",
       "requires": {
         "@babel/runtime": "^7.3.1",
-        "jss": "10.8.1",
+        "jss": "10.9.0",
         "tiny-warning": "^1.0.2"
       }
     },
     "jss-plugin-vendor-prefixer": {
-      "version": "10.8.1",
-      "resolved": "https://registry.npmjs.org/jss-plugin-vendor-prefixer/-/jss-plugin-vendor-prefixer-10.8.1.tgz",
-      "integrity": "sha512-77b/iEFmA669s+USru2Y5eg9Hs1C1N0zE/4EaJm/fqKScCTNawHXZv5l5w6j81A9CNa63Ar7jekAIfBkoKFmLw==",
+      "version": "10.9.0",
+      "resolved": "http://repo.localhost/repository/npm/jss-plugin-vendor-prefixer/-/jss-plugin-vendor-prefixer-10.9.0.tgz",
+      "integrity": "sha512-MbvsaXP7iiVdYVSEoi+blrW+AYnTDvHTW6I6zqi7JcwXdc6I9Kbm234nEblayhF38EftoenbM+5218pidmC5gA==",
       "requires": {
         "@babel/runtime": "^7.3.1",
         "css-vendor": "^2.0.8",
-        "jss": "10.8.1"
+        "jss": "10.9.0"
       }
     },
     "kind-of": {
@@ -1931,12 +1940,12 @@
     },
     "lodash.assign": {
       "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
+      "resolved": "http://repo.localhost/repository/npm/lodash.assign/-/lodash.assign-4.2.0.tgz",
       "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc="
     },
     "lodash.isplainobject": {
       "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "resolved": "http://repo.localhost/repository/npm/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
       "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
     },
     "log4js": {
@@ -1979,7 +1988,7 @@
     },
     "mdurl": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
+      "resolved": "http://repo.localhost/repository/npm/mdurl/-/mdurl-1.0.1.tgz",
       "integrity": "sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4="
     },
     "memory-fs": {
@@ -2265,7 +2274,7 @@
     },
     "pascalcase": {
       "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
+      "resolved": "http://repo.localhost/repository/npm/pascalcase/-/pascalcase-0.1.1.tgz",
       "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ="
     },
     "path-exists": {
@@ -2313,7 +2322,7 @@
     },
     "popper.js": {
       "version": "1.16.1-lts",
-      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1-lts.tgz",
+      "resolved": "http://repo.localhost/repository/npm/popper.js/-/popper.js-1.16.1-lts.tgz",
       "integrity": "sha512-Kjw8nKRl1m+VrSFCoVGPph93W/qrSO7ZkqPpTf7F4bk/sqcfWK019dWBUpE/fBOsOQY1dks/Bmcbfn1heM/IsA=="
     },
     "postcss": {
@@ -2418,13 +2427,13 @@
     },
     "raf-schd": {
       "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/raf-schd/-/raf-schd-4.0.3.tgz",
+      "resolved": "http://repo.localhost/repository/npm/raf-schd/-/raf-schd-4.0.3.tgz",
       "integrity": "sha512-tQkJl2GRWh83ui2DiPTJz9wEiMN20syf+5oKfB03yYP7ioZcJwsIK8FjrtLwH1m7C7e+Tt2yYBlrOpdT+dyeIQ=="
     },
     "ramda": {
-      "version": "0.27.1",
-      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.27.1.tgz",
-      "integrity": "sha512-PgIdVpn5y5Yns8vqb8FzBUEYn98V3xcPgawAkkgj0YJ0qDsnHCiNmZYfOGMgOvoB0eWFLpYbhxUR3mxfDIMvpw=="
+      "version": "0.27.2",
+      "resolved": "http://repo.localhost/repository/npm/ramda/-/ramda-0.27.2.tgz",
+      "integrity": "sha512-SbiLPU40JuJniHexQSAgad32hfwd+DRUdwF2PlVuI5RZD0/vahUco7R8vD86J/tcEKKF9vZrUVwgtmGCqlCKyA=="
     },
     "randombytes": {
       "version": "2.1.0",
@@ -2463,7 +2472,7 @@
     },
     "react-transition-group": {
       "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.2.tgz",
+      "resolved": "http://repo.localhost/repository/npm/react-transition-group/-/react-transition-group-4.4.2.tgz",
       "integrity": "sha512-/RNYfRAMlZwDSr6z4zNKV6xu53/e2BuaBbGhbyYIXTrmgu/bGHzmqOs7mJSJBHy9Ud+ApHx3QjrkKSp1pxvlFg==",
       "requires": {
         "@babel/runtime": "^7.5.5",
@@ -2533,7 +2542,7 @@
     },
     "regenerator-runtime": {
       "version": "0.13.9",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
+      "resolved": "http://repo.localhost/repository/npm/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
       "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA=="
     },
     "relateurl": {
@@ -2793,7 +2802,7 @@
     },
     "string.prototype.repeat": {
       "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/string.prototype.repeat/-/string.prototype.repeat-0.2.0.tgz",
+      "resolved": "http://repo.localhost/repository/npm/string.prototype.repeat/-/string.prototype.repeat-0.2.0.tgz",
       "integrity": "sha1-q6Nt4I3O5qWjN9SbLqHaGyj8Ds8="
     },
     "string.prototype.replaceall": {
@@ -2957,7 +2966,7 @@
     },
     "tiny-warning": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
+      "resolved": "http://repo.localhost/repository/npm/tiny-warning/-/tiny-warning-1.0.3.tgz",
       "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
     },
     "to-regex-range": {
@@ -3054,7 +3063,7 @@
     },
     "ts-toolbelt": {
       "version": "6.15.5",
-      "resolved": "https://registry.npmjs.org/ts-toolbelt/-/ts-toolbelt-6.15.5.tgz",
+      "resolved": "http://repo.localhost/repository/npm/ts-toolbelt/-/ts-toolbelt-6.15.5.tgz",
       "integrity": "sha512-FZIXf1ksVyLcfr7M317jbB67XFJhOO1YqdTcuGaq9q5jLUoTikukZ+98TPjKiP2jC5CgmYdWWYs0s2nLSU0/1A=="
     },
     "tslib": {
@@ -3310,7 +3319,7 @@
     },
     "xss-filters": {
       "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/xss-filters/-/xss-filters-1.2.7.tgz",
+      "resolved": "http://repo.localhost/repository/npm/xss-filters/-/xss-filters-1.2.7.tgz",
       "integrity": "sha1-Wfod4gHzby80cNysX1jMwoMLCpo="
     },
     "yallist": {

--- a/package.json
+++ b/package.json
@@ -203,7 +203,7 @@
   "dependencies": {
     "@agney/react-loading": "^0.1.2",
     "@fortawesome/free-solid-svg-icons": "^5.15.1",
-    "@sonatype/react-shared-components": "^9.0.1",
+    "@sonatype/react-shared-components": "^9.5.15",
     "@types/platform": "^1.3.2",
     "@types/temp": "^0.8.34",
     "command-exists": "^1.2.9",


### PR DESCRIPTION
This pull request makes the following changes:
* For projects that contain a `build.gradle`, `./gradlew` or `./gradlew.bat` will now take precedence over system `gradle` when looking to enumerate dependencies for analysis
* Removes duplicate application name in tree view (#227)

It relates to the following issue #s:
* Fixes #226, #227

cc @bhamail / @DarthHater / @maurycupitt 
