### PR TITLE
Dedupe components when building SBOM

### DIFF
--- a/ext-src/cyclonedx/CycloneDXGenerator.ts
+++ b/ext-src/cyclonedx/CycloneDXGenerator.ts
@@ -31,7 +31,9 @@ export class CycloneDXSbomCreator {
     const componentsNode = bom.ele('components');
     let components: Array<any> = new Array();
 
-    pkgInfo.forEach((pkg) => {
+    const pkgs = this.dedupeArray(pkgInfo);
+
+    pkgs.forEach((pkg) => {
         components.push(
           {
             component: this.getComponent(pkg)
@@ -61,6 +63,17 @@ export class CycloneDXSbomCreator {
         purl: pkg.toPurl(),
       };
     return component;
+  }
+
+  private dedupeArray(pkgs: Array<PackageType>): Array<PackageType> {
+    const uniqueArray = pkgs.filter((val, index) => {
+      const value = JSON.stringify(val);
+      return index === pkgs.findIndex((obj) => {
+        return JSON.stringify(obj) === value;
+      })
+    })
+    
+    return uniqueArray;
   }
 }
 


### PR DESCRIPTION
The SBOM creator for VSCode IQ Plugin does not dedupe it's component list, leading to duplicates when IQ parses it, failing validation.

This pull request makes the following changes:
* Adds a function to dedupe the array, based on: https://stackoverflow.com/questions/2218999/how-to-remove-all-duplicates-from-an-array-of-objects

cc @bhamail / @DarthHater 
