### PR TITLE
Make command to list Go dependencies configurable

### DIFF
--- a/ext-src/packages/golang/GolangUtils.ts
+++ b/ext-src/packages/golang/GolangUtils.ts
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import * as vscode from "vscode";
 import { readFileSync } from 'fs';
 import { join } from 'path';
 import { Readable } from 'stream';
@@ -29,10 +30,11 @@ export class GolangUtils {
   public async getDependencyArray(application: Application, scanType: string): Promise<Array<GolangPackage>> {
     try {
       if (scanType === GO_MOD_SUM) {
+        let listCommand = vscode.workspace.getConfiguration().get("nexusExplorer.goListCommand", "go list -m -json all");
 
         // TODO: When running this command, Golang is now using the workspace root to establish a GOCACHE, 
         // we should use some other temporary area or try and suss out the real one
-        let { stdout, stderr } = await exec(`go list -m -json all`, {
+        let { stdout, stderr } = await exec(listCommand, {
           cwd: application.workspaceFolder,
           env: {
             "PATH": process.env["PATH"],

--- a/package.json
+++ b/package.json
@@ -125,6 +125,19 @@
             "default": true,
             "description": "You can disable this to exclude dependencies that are used in the development or testing process only. Supported for Gradle, Maven, NPM and Poetry."
           },
+          "nexusExplorer.goListCommand": {
+            "type": "string",
+            "description": "Command to detect dependencies in a Go project",
+            "default": "go list -m -json all",
+            "enum": [
+              "go list -m -json all",
+              "go list -m -json ./..."
+            ],
+            "enumDescriptions": [
+              "Finds all modules in a Go environment",
+              "Finds modules used in the current workspace"
+            ]
+          },
           "nexusExplorer.loggingLevel": {
             "type": "string",
             "default": "ERROR",

--- a/package.json
+++ b/package.json
@@ -128,14 +128,14 @@
           "nexusExplorer.goListCommand": {
             "type": "string",
             "description": "Command to detect dependencies in a Go project",
-            "default": "go list -m -json all",
+            "default": "go list -m -json ./...",
             "enum": [
-              "go list -m -json all",
-              "go list -m -json ./..."
+              "go list -m -json ./...",
+              "go list -m -json all"
             ],
             "enumDescriptions": [
-              "Finds all modules in a Go environment",
-              "Finds modules used in the current workspace"
+              "Finds modules used in the current workspace",
+              "Finds all modules in a Go environment"
             ]
           },
           "nexusExplorer.loggingLevel": {


### PR DESCRIPTION
This pull request makes the following changes:

- Add configuration option `nexusExplorer.goListCommand`.
- Run the configured command instead of the hard coded one for listing Go dependencies.

This PR addresses the problem that in many Go environments, `go list -m -json all` will return more modules than are used in the Go project opened as a workspace in VS Code. As a result, users have to find out which reported vulnerabilities are actually relevant for the project currently working on.

With the addition of the configuration option, which defaults to the previous hard-coded value, users can easily switch this to `go list -m -json ./...`, which is a viable option if the current workspace represents one Go project with a `go.mod` and `go.sum` file in the root.

It relates to the following issue #s:

* Fixes #257 

cc @bhamail / @DarthHater 
